### PR TITLE
Feat : 활동 목록 및 활동 기록 전체 조회 API 추가

### DIFF
--- a/src/main/java/umc/kkijuk/server/career/controller/BaseCareerController.java
+++ b/src/main/java/umc/kkijuk/server/career/controller/BaseCareerController.java
@@ -42,7 +42,7 @@ public class BaseCareerController {
     }
 
     @PatchMapping("/activity/{activityId}")
-    @Operation(summary = "커리어(대외활동) 수정", description = "활동 ID에 해당하는 활동을 수정합니다..")
+    @Operation(summary = "커리어(대외활동) 수정", description = "활동 ID에 해당하는 활동을 수정합니다.")
     @Parameter(name="activityId", description = "커리어(대외활동) Id, path variable 입니다.",example = "1")
     public CareerResponse<ActivityResponse> updateActivity(
             @Login LoginInfo loginInfo,
@@ -96,7 +96,7 @@ public class BaseCareerController {
     }
 
     @PatchMapping("/competition/{competitionId}")
-    @Operation(summary = "커리어(대회) 수정", description = "활동 ID에 해당하는 활동을 수정합니다..")
+    @Operation(summary = "커리어(대회) 수정", description = "활동 ID에 해당하는 활동을 수정합니다.")
     @Parameter(name="competitionId", description = "커리어(대회) Id, path variable 입니다.",example = "1")
     public CareerResponse<CompetitionResponse> updateComp(
             @Login LoginInfo loginInfo,
@@ -123,7 +123,7 @@ public class BaseCareerController {
     }
 
     @PatchMapping("/educareer/{educareerId}")
-    @Operation(summary = "커리어(교육) 수정", description = "활동 ID에 해당하는 활동을 수정합니다..")
+    @Operation(summary = "커리어(교육) 수정", description = "활동 ID에 해당하는 활동을 수정합니다.")
     @Parameter(name="educareerId", description = "커리어(교육) Id, path variable 입니다.",example = "1")
     public CareerResponse<EduCareerResponse> updateEdu(
             @Login LoginInfo loginInfo,
@@ -150,7 +150,7 @@ public class BaseCareerController {
         );
     }
     @PatchMapping("/employment/{employmentId}")
-    @Operation(summary = "커리어(경력) 수정", description = "활동 ID에 해당하는 활동을 수정합니다..")
+    @Operation(summary = "커리어(경력) 수정", description = "활동 ID에 해당하는 활동을 수정합니다.")
     @Parameter(name="employmentId", description = "커리어(아르바이트/인턴) Id, path variable 입니다.",example = "1")
     public CareerResponse<EmploymentResponse> updateEmp(
             @Login LoginInfo loginInfo,
@@ -178,7 +178,7 @@ public class BaseCareerController {
     }
 
     @PatchMapping("/project/{projectId}")
-    @Operation(summary = "커리어(프로젝트) 수정", description = "활동 ID에 해당하는 활동을 수정합니다..")
+    @Operation(summary = "커리어(프로젝트) 수정", description = "활동 ID에 해당하는 활동을 수정합니다.")
     @Parameter(name="projectId", description = "커리어(프로젝트) Id, path variable 입니다.",example = "1")
     public CareerResponse<ProjectResponse> updateProject(
             @Login LoginInfo loginInfo,
@@ -194,7 +194,7 @@ public class BaseCareerController {
     @GetMapping("")
     @Operation(
             summary = "활동 목록",
-            description = "활동을 카테고리, 연도 별로 조회합니다. query 값으로  category(카테고리 기준)나, year(연도 기준) 값을 주세요. " )
+            description = "활동을 조회합니다. query 값으로 category(카테고리 기준), year(연도 기준), 또는 all(전체 조회) 중 하나를 선택하여 요청해주세요." )
     public CareerResponse<?> findAllCareersGroupedYear(
             @Login LoginInfo loginInfo,
             @RequestParam(name="status") String value
@@ -204,6 +204,11 @@ public class BaseCareerController {
             return CareerResponse.success(
                     CareerResponseMessage.CAREER_FINDALL_SUCCESS,
                     baseCareerService.findAllCareerGroupedCategory(requestMember.getId())
+            );
+        }else if (value.equals("all")){
+            return CareerResponse.success(
+              CareerResponseMessage.CAREER_FINDALL_SUCCESS,
+              baseCareerService.findAllCareer(requestMember.getId())
             );
         }
         return CareerResponse.success(
@@ -260,7 +265,7 @@ public class BaseCareerController {
     @GetMapping("/find/detail")
     @Operation(
             summary = "활동 검색 - 활동 기록",
-            description = "활동기록을 주어진 조건에 맞추어 조회합니다. query 값으로 검색어(keyword)와 정렬 기준(new,old)을 주세요. " )
+            description = "활동기록을 주어진 조건에 맞추어 조회합니다. query 값으로 검색어(keyword)와 정렬 기준(new,old)을 요청해주세요. " )
     public CareerResponse<List<FindDetailResponse>> findDetail(
             @Login LoginInfo loginInfo,
             @RequestParam(name="keyword")String keyword,
@@ -277,7 +282,7 @@ public class BaseCareerController {
     @Operation(
             summary = "활동 검색 - 태그 ( 검색 태그 조회 )",
             description = "검색어를 포함하는 활동 태그들을 가나다 순으로 조회합니다.  " +
-                    "query 값으로 검색어(keyword)를 주세요. " )
+                    "query 값으로 검색어(keyword)를 요청해주세요. " )
     public CareerResponse<List<FindTagResponse>> findTag(
             @Login LoginInfo loginInfo,
             @RequestParam(name="keyword")String keyword
@@ -293,7 +298,7 @@ public class BaseCareerController {
     @Operation(
             summary = "활동 검색 - 태그 ( 선택한 태그에 대한 활동 기록 조회 )",
             description = "선택한 태그를 포함하는 활동 기록들을 조회합니다. " +
-                    " query 값으로 태그의 ID 와 정렬 기준(new,old)을 주세요. " )
+                    " query 값으로 태그의 ID 와 정렬 기준(new,old)을 요청해주세요. " )
     public CareerResponse<List<FindDetailResponse>> findTagAndDetail(
             @Login LoginInfo loginInfo,
             @RequestParam(name="tagId") Long tagId,
@@ -308,7 +313,7 @@ public class BaseCareerController {
     @GetMapping("/find")
     @Operation(
             summary = "활동 검색 - 활동",
-            description =  "활동을 주어진 조건에 맞추어 조회합니다. query 값으로 검색어(keyword)와 정렬 기준(new,old)을 주세요. " )
+            description =  "활동을 주어진 조건에 맞추어 조회합니다. query 값으로 검색어(keyword)와 정렬 기준(new,old)을 요청해주세요. " )
     public CareerResponse<List<FindCareerResponse>> findCareerWithKeyword(
             @Login LoginInfo loginInfo,
             @RequestParam(name = "keyword") String keyword,

--- a/src/main/java/umc/kkijuk/server/career/service/BaseCareerService.java
+++ b/src/main/java/umc/kkijuk/server/career/service/BaseCareerService.java
@@ -60,4 +60,6 @@ public interface BaseCareerService {
     List<FindCareerResponse> findCareerWithKeyword(Member requestMember, String keyword, String sort);
 
     List<TimelineResponse> findCareerForTimeline(Member requestMember);
+
+    List<BaseCareerResponse> findAllCareer(Long memberId);
 }

--- a/src/main/java/umc/kkijuk/server/career/service/BaseCareerServiceImpl.java
+++ b/src/main/java/umc/kkijuk/server/career/service/BaseCareerServiceImpl.java
@@ -350,7 +350,7 @@ public class BaseCareerServiceImpl implements BaseCareerService{
                 .map(EmploymentResponse::new).collect(Collectors.toList()));
 
 
-        baseCareers.stream().sorted(Comparator.comparing(BaseCareerResponse::getEndDate).reversed());
+//        baseCareers.stream().sorted(Comparator.comparing(BaseCareerResponse::getEndDate).reversed());
 
         baseCareers = baseCareers.stream()
                 .sorted(Comparator.comparing(BaseCareerResponse::getEndDate).reversed())
@@ -372,6 +372,35 @@ public class BaseCareerServiceImpl implements BaseCareerService{
         }
         return result;
     }
+
+
+    @Override
+    public List<BaseCareerResponse> findAllCareer(Long memberId) {
+        List<BaseCareerResponse> baseCareers = projectRepository.findByMemberId(memberId).stream()
+                .map(project-> new ProjectResponse(project,detailRepository.findByProject(project)))
+                .collect(Collectors.toList());
+        baseCareers.addAll(competitionRepository.findByMemberId(memberId).stream()
+                .map(comp-> new CompetitionResponse(comp, detailRepository.findByCompetition(comp)))
+                .collect(Collectors.toList()));
+        baseCareers.addAll(activityRepository.findByMemberId(memberId).stream()
+                .map(activity->new ActivityResponse(activity, detailRepository.findByActivity(activity)))
+                .collect(Collectors.toList()));
+        baseCareers.addAll(circleRepository.findByMemberId(memberId).stream()
+                .map(circle-> new CircleResponse(circle, detailRepository.findByCircle(circle)))
+                .collect(Collectors.toList()));
+        baseCareers.addAll(eduCareerRepository.findByMemberId(memberId).stream()
+                .map(eduCareer -> new EduCareerResponse(eduCareer, detailRepository.findByEduCareer(eduCareer)))
+                .collect(Collectors.toList()));
+        baseCareers.addAll(employmentRepository.findByMemberId(memberId).stream()
+                .map(employment -> new EmploymentResponse(employment, detailRepository.findByEmployment(employment)))
+                .collect(Collectors.toList()));
+
+        baseCareers = baseCareers.stream()
+                .sorted(Comparator.comparing(BaseCareerResponse::getEndDate).reversed())
+                .collect(Collectors.toList());
+        return baseCareers;
+    }
+
     @Override
     public BaseCareerResponse findCareer(Member requestMember, Long careerId, String type) {
         switch (type.toLowerCase()) {
@@ -655,17 +684,24 @@ public class BaseCareerServiceImpl implements BaseCareerService{
     private <T extends BaseCareer, R extends BaseCareerResponse> R getResponse(T career,  BiFunction<T, List<BaseCareerDetail>, R> responseConstructor) {
         List<BaseCareerDetail> details;
         if (career instanceof Activity) {
-            details = detailRepository.findByActivity((Activity) career);
+            details = Optional.ofNullable(detailRepository.findByActivity((Activity) career))
+                    .orElseGet(Collections::emptyList);
         } else if (career instanceof Circle) {
-            details = detailRepository.findByCircle((Circle) career);
+            details = Optional.ofNullable(detailRepository.findByCircle((Circle) career))
+                    .orElseGet(Collections::emptyList);
         } else if (career instanceof Competition) {
-            details = detailRepository.findByCompetition((Competition) career);
+            details = Optional.ofNullable(detailRepository.findByCompetition((Competition) career))
+                    .orElseGet(Collections::emptyList);
         } else if (career instanceof EduCareer) {
-            details = detailRepository.findByEduCareer((EduCareer) career);
+            details =Optional.ofNullable(detailRepository.findByEduCareer((EduCareer) career))
+                    .orElseGet(Collections::emptyList);
         } else if (career instanceof Employment) {
-            details = detailRepository.findByEmployment((Employment) career);
+            details = Optional.ofNullable( detailRepository.findByEmployment((Employment) career))
+                    .orElseGet(Collections::emptyList);
+
         } else if (career instanceof Project) {
-            details = detailRepository.findByProject((Project) career);
+            details = Optional.ofNullable( detailRepository.findByProject((Project) career))
+                    .orElseGet(Collections::emptyList);
         } else {
             throw new IllegalArgumentException("지원하지 않는 타입입니다.");
         }

--- a/src/main/java/umc/kkijuk/server/detail/repository/BaseCareerDetailRepository.java
+++ b/src/main/java/umc/kkijuk/server/detail/repository/BaseCareerDetailRepository.java
@@ -10,38 +10,38 @@ import java.util.List;
 
 public interface BaseCareerDetailRepository extends JpaRepository<BaseCareerDetail,Long> {
     @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
-            "JOIN FETCH bcd.careerTagList ct " +
-            "JOIN FETCH  ct.tag t " +
+            "LEFT JOIN FETCH bcd.careerTagList ct " +
+            "LEFT JOIN FETCH  ct.tag t " +
             "WHERE bcd.competition = :competition")
     List<BaseCareerDetail> findByCompetition(Competition competition);
     @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
-            "JOIN FETCH bcd.careerTagList ct " +
-            "JOIN FETCH ct.tag t " +
+            "LEFT JOIN FETCH bcd.careerTagList ct " +
+            "LEFT JOIN FETCH ct.tag t " +
             "WHERE bcd.activity = :activity")
     List<BaseCareerDetail> findByActivity(Activity activity);
     @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
-            "JOIN FETCH bcd.careerTagList ct " +
-            "JOIN FETCH ct.tag t " +
+            "LEFT JOIN FETCH bcd.careerTagList ct " +
+            "LEFT JOIN FETCH ct.tag t " +
             "WHERE bcd.circle = :circle")
     List<BaseCareerDetail> findByCircle(Circle circle);
     @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
-            "JOIN FETCH bcd.careerTagList ct " +
-            "JOIN FETCH ct.tag t " +
+            "LEFT JOIN FETCH bcd.careerTagList ct " +
+            "LEFT JOIN FETCH ct.tag t " +
             "WHERE bcd.project = :project")
     List<BaseCareerDetail> findByProject(Project project);
     @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
-            "JOIN FETCH bcd.careerTagList ct " +
-            "JOIN FETCH ct.tag t " +
+            "LEFT JOIN FETCH bcd.careerTagList ct " +
+            "LEFT JOIN FETCH ct.tag t " +
             "WHERE bcd.eduCareer = :edu")
     List<BaseCareerDetail> findByEduCareer(EduCareer edu);
     @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
-            "JOIN FETCH bcd.careerTagList ct " +
-            "JOIN FETCH ct.tag t " +
+            "LEFT JOIN FETCH bcd.careerTagList ct " +
+            "LEFT JOIN FETCH ct.tag t " +
             "WHERE bcd.employment = :emp")
     List<BaseCareerDetail> findByEmployment(Employment emp);
     @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
-            "JOIN FETCH bcd.careerTagList ct " +
-            "JOIN FETCH ct.tag t " +
+            "LEFT JOIN FETCH bcd.careerTagList ct " +
+            "LEFT JOIN FETCH ct.tag t " +
             "WHERE bcd.memberId = :memberId " +
             "AND(bcd.title LIKE %:keyword% OR bcd.content LIKE %:keyword%)")
     List<BaseCareerDetail> findByMemberIdAndKeyword(@Param("memberId") Long memberId, @Param("keyword") String keyword);


### PR DESCRIPTION
- 활동 목록 및 활동 기록을 전체 조회하는 API를 추가하였습니다.
- LEFT JOIN FETCH로 연관된 태그 데이터가 없는 경우에도 BaseCareerDetail를 조회 가능하도록 수정하였습니다.
