### PR TITLE
Refactor : Dashboard API, 이력서 조회, CareerDetail 연관관계, 타임라인 API 개선

### DIFF
--- a/src/main/java/umc/kkijuk/server/career/controller/BaseCareerController.java
+++ b/src/main/java/umc/kkijuk/server/career/controller/BaseCareerController.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import umc.kkijuk.server.career.controller.response.*;
 import umc.kkijuk.server.career.dto.*;
-import umc.kkijuk.server.career.service.BaseCareerService;
+import umc.kkijuk.server.career.service.CareerService;
 import umc.kkijuk.server.login.argumentresolver.Login;
 import umc.kkijuk.server.login.controller.dto.LoginInfo;
 import umc.kkijuk.server.member.domain.Member;
@@ -22,7 +22,7 @@ import umc.kkijuk.server.member.service.MemberService;
 @RequiredArgsConstructor
 @RequestMapping("/career")
 public class BaseCareerController {
-    private final BaseCareerService baseCareerService;
+    private final CareerService baseCareerService;
     private final MemberService memberService;
 
     @PostMapping("/activity")

--- a/src/main/java/umc/kkijuk/server/career/controller/CareerSearchController.java
+++ b/src/main/java/umc/kkijuk/server/career/controller/CareerSearchController.java
@@ -1,0 +1,142 @@
+package umc.kkijuk.server.career.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import umc.kkijuk.server.career.controller.response.*;
+import umc.kkijuk.server.career.service.BaseCareerService;
+import umc.kkijuk.server.login.argumentresolver.Login;
+import umc.kkijuk.server.login.controller.dto.LoginInfo;
+import umc.kkijuk.server.member.domain.Member;
+import umc.kkijuk.server.member.service.MemberService;
+
+import java.util.List;
+
+@Tag(name="Search Career", description = "활동 조회 및 검색 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/career")
+public class CareerSearchController {
+    private final BaseCareerService baseCareerService;
+    private final MemberService memberService;
+    @GetMapping("")
+    @Operation(
+            summary = "활동 목록",
+            description = "활동을 조회합니다. query 값으로 category(카테고리 기준), year(연도 기준), 또는 all(전체 조회) 중 하나를 선택하여 요청해주세요." )
+    public CareerResponse<?> findAllCareersGroupedYear(
+            @Login LoginInfo loginInfo,
+            @RequestParam(name="status") String value
+    ) {
+        Member requestMember = memberService.getById(loginInfo.getMemberId());
+        if(value.equals("category")){
+            return CareerResponse.success(
+                    CareerResponseMessage.CAREER_FINDALL_SUCCESS,
+                    baseCareerService.findAllCareerGroupedCategory(requestMember.getId())
+            );
+        }else if (value.equals("all")){
+            return CareerResponse.success(
+                    CareerResponseMessage.CAREER_FINDALL_SUCCESS,
+                    baseCareerService.findAllCareer(requestMember.getId())
+            );
+        }
+        return CareerResponse.success(
+                CareerResponseMessage.CAREER_FINDALL_SUCCESS,
+                baseCareerService.findAllCareerGroupedYear(requestMember.getId())
+        );
+    }
+    @GetMapping("/{type}/{careerId}")
+    @Operation(summary = "활동 상세", description = "활동 ID에 해당하는 활동의 세부 내용과, 활동 기록을 조회합니다.")
+    @Parameter(name = "careerId", description = "활동 Id, path variable 입니다.", example = "1")
+    public CareerResponse<BaseCareerResponse> findCareer(
+            @Login LoginInfo loginInfo,
+            @PathVariable String type,
+            @PathVariable Long careerId
+    ){
+        Member requestMember = memberService.getById(loginInfo.getMemberId());
+        return CareerResponse.success(
+                CareerResponseMessage.CAREER_FINDALL_SUCCESS,
+                baseCareerService.findCareer(requestMember, careerId, type)
+        );
+    }
+    @GetMapping("/find/detail")
+    @Operation(
+            summary = "활동 검색 - 활동 기록",
+            description = "활동기록을 주어진 조건에 맞추어 조회합니다. query 값으로 검색어(keyword)와 정렬 기준(new,old)을 요청해주세요. " )
+    public CareerResponse<List<FindDetailResponse>> findDetail(
+            @Login LoginInfo loginInfo,
+            @RequestParam(name="keyword")String keyword,
+            @RequestParam(name="sort") String sort
+    ) {
+        Member reqeustMember = memberService.getById(loginInfo.getMemberId());
+        return CareerResponse.success(
+                CareerResponseMessage.CAREER_FINDALL_SUCCESS,
+                baseCareerService.findAllDetail(reqeustMember,keyword,sort)
+        );
+    }
+
+    @GetMapping("/find/taglist")
+    @Operation(
+            summary = "활동 검색 - 태그 ( 검색 태그 조회 )",
+            description = "검색어를 포함하는 활동 태그들을 가나다 순으로 조회합니다.  " +
+                    "query 값으로 검색어(keyword)를 요청해주세요. " )
+    public CareerResponse<List<FindTagResponse>> findTag(
+            @Login LoginInfo loginInfo,
+            @RequestParam(name="keyword")String keyword
+    ) {
+        Member requestMember = memberService.getById(loginInfo.getMemberId());
+        return CareerResponse.success(
+                CareerResponseMessage.CAREER_SEARCH_SUCCESS,
+                baseCareerService.findAllTag(requestMember, keyword)
+        );
+    }
+
+    @GetMapping("/find/tag")
+    @Operation(
+            summary = "활동 검색 - 태그 ( 선택한 태그에 대한 활동 기록 조회 )",
+            description = "선택한 태그를 포함하는 활동 기록들을 조회합니다. " +
+                    " query 값으로 태그의 ID 와 정렬 기준(new,old)을 요청해주세요. " )
+    public CareerResponse<List<FindDetailResponse>> findTagAndDetail(
+            @Login LoginInfo loginInfo,
+            @RequestParam(name="tagId") Long tagId,
+            @RequestParam(name="sort") String sort
+    ){
+        Member requestMember = memberService.getById(loginInfo.getMemberId());
+        return CareerResponse.success(
+                CareerResponseMessage.CAREER_FINDALL_SUCCESS,
+                baseCareerService.findAllDetailByTag(requestMember, tagId, sort)
+        );
+    }
+    @GetMapping("/find")
+    @Operation(
+            summary = "활동 검색 - 활동",
+            description =  "활동을 주어진 조건에 맞추어 조회합니다. query 값으로 검색어(keyword)와 정렬 기준(new,old)을 요청해주세요. " )
+    public CareerResponse<List<FindCareerResponse>> findCareerWithKeyword(
+            @Login LoginInfo loginInfo,
+            @RequestParam(name = "keyword") String keyword,
+            @RequestParam(name = "sort") String sort
+    ){
+        Member requestMember = memberService.getById(loginInfo.getMemberId());
+        return CareerResponse.success(
+                CareerResponseMessage.CAREER_FINDALL_SUCCESS,
+                baseCareerService.findCareerWithKeyword(requestMember, keyword, sort)
+        );
+
+    }
+    @GetMapping("/timeline")
+    @Operation(
+            summary = "활동 타임라인",
+            description = "타임라인에 필요한 활동 정보들을 조회합니다.")
+    public CareerResponse<List<TimelineResponse>> findCareerForTimeline(
+            @Login LoginInfo loginInfo
+    ){
+        Member requestMember = memberService.getById(loginInfo.getMemberId());
+        return CareerResponse.success(
+                CareerResponseMessage.CAREER_FINDALL_SUCCESS,
+                baseCareerService.findCareerForTimeline(requestMember)
+        );
+
+    }
+
+}

--- a/src/main/java/umc/kkijuk/server/career/controller/CareerSearchController.java
+++ b/src/main/java/umc/kkijuk/server/career/controller/CareerSearchController.java
@@ -6,7 +6,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import umc.kkijuk.server.career.controller.response.*;
-import umc.kkijuk.server.career.service.BaseCareerService;
+import umc.kkijuk.server.career.service.CareerSearchService;
+import umc.kkijuk.server.career.service.CareerService;
 import umc.kkijuk.server.login.argumentresolver.Login;
 import umc.kkijuk.server.login.controller.dto.LoginInfo;
 import umc.kkijuk.server.member.domain.Member;
@@ -19,7 +20,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/career")
 public class CareerSearchController {
-    private final BaseCareerService baseCareerService;
+    private final CareerSearchService careerSearchService;
     private final MemberService memberService;
     @GetMapping("")
     @Operation(
@@ -33,17 +34,17 @@ public class CareerSearchController {
         if(value.equals("category")){
             return CareerResponse.success(
                     CareerResponseMessage.CAREER_FINDALL_SUCCESS,
-                    baseCareerService.findAllCareerGroupedCategory(requestMember.getId())
+                    careerSearchService.findAllCareerGroupedCategory(requestMember.getId())
             );
         }else if (value.equals("all")){
             return CareerResponse.success(
                     CareerResponseMessage.CAREER_FINDALL_SUCCESS,
-                    baseCareerService.findAllCareer(requestMember.getId())
+                    careerSearchService.findAllCareer(requestMember.getId())
             );
         }
         return CareerResponse.success(
                 CareerResponseMessage.CAREER_FINDALL_SUCCESS,
-                baseCareerService.findAllCareerGroupedYear(requestMember.getId())
+                careerSearchService.findAllCareerGroupedYear(requestMember.getId())
         );
     }
     @GetMapping("/{type}/{careerId}")
@@ -57,7 +58,7 @@ public class CareerSearchController {
         Member requestMember = memberService.getById(loginInfo.getMemberId());
         return CareerResponse.success(
                 CareerResponseMessage.CAREER_FINDALL_SUCCESS,
-                baseCareerService.findCareer(requestMember, careerId, type)
+                careerSearchService.findCareer(requestMember, careerId, type)
         );
     }
     @GetMapping("/find/detail")
@@ -72,7 +73,7 @@ public class CareerSearchController {
         Member reqeustMember = memberService.getById(loginInfo.getMemberId());
         return CareerResponse.success(
                 CareerResponseMessage.CAREER_FINDALL_SUCCESS,
-                baseCareerService.findAllDetail(reqeustMember,keyword,sort)
+                careerSearchService.findAllDetail(reqeustMember,keyword,sort)
         );
     }
 
@@ -88,7 +89,7 @@ public class CareerSearchController {
         Member requestMember = memberService.getById(loginInfo.getMemberId());
         return CareerResponse.success(
                 CareerResponseMessage.CAREER_SEARCH_SUCCESS,
-                baseCareerService.findAllTag(requestMember, keyword)
+                careerSearchService.findAllTag(requestMember, keyword)
         );
     }
 
@@ -105,7 +106,7 @@ public class CareerSearchController {
         Member requestMember = memberService.getById(loginInfo.getMemberId());
         return CareerResponse.success(
                 CareerResponseMessage.CAREER_FINDALL_SUCCESS,
-                baseCareerService.findAllDetailByTag(requestMember, tagId, sort)
+                careerSearchService.findAllDetailByTag(requestMember, tagId, sort)
         );
     }
     @GetMapping("/find")
@@ -120,7 +121,7 @@ public class CareerSearchController {
         Member requestMember = memberService.getById(loginInfo.getMemberId());
         return CareerResponse.success(
                 CareerResponseMessage.CAREER_FINDALL_SUCCESS,
-                baseCareerService.findCareerWithKeyword(requestMember, keyword, sort)
+                careerSearchService.findCareerWithKeyword(requestMember, keyword, sort)
         );
 
     }
@@ -134,7 +135,7 @@ public class CareerSearchController {
         Member requestMember = memberService.getById(loginInfo.getMemberId());
         return CareerResponse.success(
                 CareerResponseMessage.CAREER_FINDALL_SUCCESS,
-                baseCareerService.findCareerForTimeline(requestMember)
+                careerSearchService.findCareerForTimeline(requestMember)
         );
 
     }

--- a/src/main/java/umc/kkijuk/server/career/controller/response/CategoryResponse.java
+++ b/src/main/java/umc/kkijuk/server/career/controller/response/CategoryResponse.java
@@ -1,0 +1,15 @@
+package umc.kkijuk.server.career.controller.response;
+
+import lombok.*;
+
+@Data
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class CategoryResponse {
+    private int categoryId;
+    private String categoryKoName;
+    private String categoryEnName;
+
+}

--- a/src/main/java/umc/kkijuk/server/career/controller/response/EtcResponse.java
+++ b/src/main/java/umc/kkijuk/server/career/controller/response/EtcResponse.java
@@ -1,0 +1,51 @@
+package umc.kkijuk.server.career.controller.response;
+
+import lombok.*;
+import umc.kkijuk.server.career.domain.CareerEtc;
+import umc.kkijuk.server.detail.controller.response.BaseCareerDetailResponse;
+import umc.kkijuk.server.detail.domain.BaseCareerDetail;
+import umc.kkijuk.server.detail.domain.CareerType;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class EtcResponse implements BaseCareerResponse{
+    private Long id;
+    private String category;
+    private String name;
+    private String alias;
+    private Boolean unknown;
+    private String summary;
+    private LocalDate startdate;
+    private LocalDate enddate;
+    private List<BaseCareerDetailResponse> detailList;
+
+    public EtcResponse(CareerEtc etc) {
+        this.id = etc.getId();
+        this.category = CareerType.ETC.getDescription();
+        this.name = etc.getName();
+        this.alias = etc.getAlias();
+        this.unknown = etc.getUnknown();
+        this.summary = etc.getSummary();
+        this.startdate = etc.getStartdate();
+        this.enddate = etc.getEnddate();
+    }
+
+    public EtcResponse(CareerEtc etc, List<BaseCareerDetail> details) {
+        this(etc);
+        this.detailList = details.stream()
+                .map(BaseCareerDetailResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public LocalDate getEndDate() {
+        return null;
+    }
+}

--- a/src/main/java/umc/kkijuk/server/career/controller/response/EtcResponse.java
+++ b/src/main/java/umc/kkijuk/server/career/controller/response/EtcResponse.java
@@ -46,6 +46,6 @@ public class EtcResponse implements BaseCareerResponse{
 
     @Override
     public LocalDate getEndDate() {
-        return null;
+        return enddate;
     }
 }

--- a/src/main/java/umc/kkijuk/server/career/controller/response/FindCareerResponse.java
+++ b/src/main/java/umc/kkijuk/server/career/controller/response/FindCareerResponse.java
@@ -2,8 +2,11 @@ package umc.kkijuk.server.career.controller.response;
 
 import lombok.*;
 import umc.kkijuk.server.career.domain.BaseCareer;
+import umc.kkijuk.server.detail.controller.response.BaseCareerDetailResponse;
+import umc.kkijuk.server.detail.domain.CareerType;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Data
 @Getter
@@ -12,19 +15,21 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class FindCareerResponse {
     private Long careerId;
-    private String careerType;
     private String careerTitle;
     private String careerAlias;
     private LocalDate startdate;
     private LocalDate enddate;
+    private CategoryResponse category;
 
-    public FindCareerResponse(BaseCareer career, String careerType){
-        this.careerId = career.getId();
-        this.careerType = careerType;
-        this.careerTitle = career.getName();
-        this.careerAlias = career.getAlias();
-        this.startdate = career.getStartdate();
-        this.enddate = career.getEnddate();
+
+    public FindCareerResponse(Long careerId, String careerTitle, String careerAlias,
+                              LocalDate startdate, LocalDate enddate, CareerType type){
+        this.careerId = careerId;
+        this.careerTitle = careerTitle;
+        this.careerAlias = careerAlias;
+        this.startdate = startdate;
+        this.enddate = enddate;
+        this.category = new CategoryResponse(type.getId(),type.getDescription(),type.name());
     }
 
 }

--- a/src/main/java/umc/kkijuk/server/career/controller/response/FindDetailResponse.java
+++ b/src/main/java/umc/kkijuk/server/career/controller/response/FindDetailResponse.java
@@ -1,7 +1,9 @@
 package umc.kkijuk.server.career.controller.response;
 
 import lombok.*;
+import umc.kkijuk.server.career.domain.BaseCareer;
 import umc.kkijuk.server.detail.controller.response.BaseCareerDetailResponse;
+import umc.kkijuk.server.detail.domain.CareerType;
 
 
 import java.time.LocalDate;
@@ -14,16 +16,26 @@ import java.util.List;
 @AllArgsConstructor
 public class FindDetailResponse implements BaseCareerResponse {
     private Long careerId;
-    private String careerType;
+    private CategoryResponse category;
     private String careerTitle;
     private String careerAlias;
     private LocalDate startdate;
     private LocalDate enddate;
     private List<BaseCareerDetailResponse> detailList;
 
-
     @Override
     public LocalDate getEndDate() {
         return this.enddate;
+    }
+
+    public FindDetailResponse(Long careerId, String careerTitle, String careerAlias, LocalDate startdate, LocalDate enddate,
+                              List<BaseCareerDetailResponse> detailList, CareerType type){
+        this.careerId = careerId;
+        this.careerTitle = careerTitle;
+        this.careerAlias = careerAlias;
+        this.startdate = startdate;
+        this.enddate = enddate;
+        this.detailList = detailList;
+        this.category = new CategoryResponse(type.getId(),type.getDescription(),type.name());
     }
 }

--- a/src/main/java/umc/kkijuk/server/career/controller/response/TimelineResponse.java
+++ b/src/main/java/umc/kkijuk/server/career/controller/response/TimelineResponse.java
@@ -2,8 +2,11 @@ package umc.kkijuk.server.career.controller.response;
 
 import lombok.*;
 import umc.kkijuk.server.career.domain.BaseCareer;
+import umc.kkijuk.server.detail.domain.CareerType;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collector;
 
 @Data
 @Getter
@@ -12,16 +15,15 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class TimelineResponse {
     private Long careerId;
-    private String category;
+    private CategoryResponse category;
     private String title;
     private LocalDate startdate;
     private LocalDate enddate;
-    public TimelineResponse(BaseCareer career, String type){
+    public TimelineResponse(BaseCareer career, CareerType type){
         this.careerId = career.getId();
         this.title = career.getName();
         this.startdate = career.getStartdate();
         this.enddate = career.getEnddate();
-        this.category = type;
+        this.category = new CategoryResponse(type.getId(),type.getDescription(),type.name());
     }
-
 }

--- a/src/main/java/umc/kkijuk/server/career/domain/Activity.java
+++ b/src/main/java/umc/kkijuk/server/career/domain/Activity.java
@@ -13,7 +13,8 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Activity extends BaseCareer {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String organizer;
     private String role;
@@ -21,8 +22,11 @@ public class Activity extends BaseCareer {
     private int contribution;
     private Boolean isTeam;
 
-    @OneToMany(mappedBy = "activity", cascade = CascadeType.ALL)
-    private List<BaseCareerDetail> detailList = new ArrayList<>();
+//    @OneToMany(mappedBy = "activity", cascade = CascadeType.ALL)
+//    private List<BaseCareerDetail> detailList = new ArrayList<>();
+//    @Convert(converter = LongListConverter.class)
+//    private List<Long> details = new ArrayList<>();
+
     @Override
     public Long getId() {
         return id;
@@ -32,19 +36,21 @@ public class Activity extends BaseCareer {
     public void setSummary(String summary) {
         super.setSummary(summary);
     }
+
     @Builder
     public Activity(Long memberId, String name, String alias, Boolean unknown,
                     LocalDate startdate, LocalDate enddate, String organizer,
                     String role, int teamSize, int contribution,
                     Boolean isTeam) {
-        super(memberId, name, alias, unknown,startdate, enddate);
+        super(memberId, name, alias, unknown, startdate, enddate);
         this.organizer = organizer;
         this.role = role;
         this.teamSize = teamSize;
         this.contribution = contribution;
         this.isTeam = isTeam;
     }
-    public void updateActivity(String name, String alias, Boolean unknown,LocalDate startdate,
+
+    public void updateActivity(String name, String alias, Boolean unknown, LocalDate startdate,
                                LocalDate enddate, String organizer, String role, int teamSize,
                                int contribution, Boolean isTeam) {
 

--- a/src/main/java/umc/kkijuk/server/career/domain/Activity.java
+++ b/src/main/java/umc/kkijuk/server/career/domain/Activity.java
@@ -34,8 +34,7 @@ public class Activity extends BaseCareer {
     }
     @Builder
     public Activity(Long memberId, String name, String alias, Boolean unknown,
-                    String summary, LocalDate startdate,
-                    LocalDate enddate, String organizer,
+                    LocalDate startdate, LocalDate enddate, String organizer,
                     String role, int teamSize, int contribution,
                     Boolean isTeam) {
         super(memberId, name, alias, unknown,startdate, enddate);

--- a/src/main/java/umc/kkijuk/server/career/domain/CareerEtc.java
+++ b/src/main/java/umc/kkijuk/server/career/domain/CareerEtc.java
@@ -1,12 +1,12 @@
 package umc.kkijuk.server.career.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
+import umc.kkijuk.server.detail.domain.BaseCareerDetail;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -16,6 +16,10 @@ public class CareerEtc extends BaseCareer{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @OneToMany(mappedBy = "etc", cascade = CascadeType.ALL)
+    private List<BaseCareerDetail> detailList = new ArrayList<>();
+
     @Override
     public Long getId() {
         return id;

--- a/src/main/java/umc/kkijuk/server/career/domain/CareerEtc.java
+++ b/src/main/java/umc/kkijuk/server/career/domain/CareerEtc.java
@@ -1,0 +1,37 @@
+package umc.kkijuk.server.career.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CareerEtc extends BaseCareer{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Override
+    public Long getId() {
+        return id;
+    }
+    @Override
+    public void setSummary(String summary) {
+        super.setSummary(summary);
+    }
+    @Builder
+    public CareerEtc(Long memberId, String name, String alias, Boolean unknown,
+                    LocalDate startdate, LocalDate enddate) {
+        super(memberId, name, alias, unknown,startdate, enddate);
+    }
+    public void updateCareerEtc(String name, String alias, Boolean unknown,
+                                 LocalDate startdate, LocalDate enddate ) {
+        this.updateBaseCareer(name, alias, unknown, startdate, enddate);
+    }
+
+}

--- a/src/main/java/umc/kkijuk/server/career/domain/CareerEtc.java
+++ b/src/main/java/umc/kkijuk/server/career/domain/CareerEtc.java
@@ -17,8 +17,8 @@ public class CareerEtc extends BaseCareer{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToMany(mappedBy = "etc", cascade = CascadeType.ALL)
-    private List<BaseCareerDetail> detailList = new ArrayList<>();
+//    @OneToMany(mappedBy = "etc", cascade = CascadeType.ALL)
+//    private List<BaseCareerDetail> detailList = new ArrayList<>();
 
     @Override
     public Long getId() {

--- a/src/main/java/umc/kkijuk/server/career/domain/Circle.java
+++ b/src/main/java/umc/kkijuk/server/career/domain/Circle.java
@@ -18,8 +18,8 @@ public class Circle extends BaseCareer{
     private Boolean location;
     private String role;
 
-    @OneToMany(mappedBy = "circle", cascade = CascadeType.ALL)
-    private List<BaseCareerDetail> detailList = new ArrayList<>();
+//    @OneToMany(mappedBy = "circle", cascade = CascadeType.ALL)
+//    private List<BaseCareerDetail> detailList = new ArrayList<>();
     @Override
     public Long getId() {
         return id;

--- a/src/main/java/umc/kkijuk/server/career/domain/Competition.java
+++ b/src/main/java/umc/kkijuk/server/career/domain/Competition.java
@@ -22,8 +22,8 @@ public class Competition extends BaseCareer{
     private int contribution;
     private Boolean isTeam;
 
-    @OneToMany(mappedBy = "competition", cascade = CascadeType.ALL)
-    private List<BaseCareerDetail> detailList = new ArrayList<>();
+//    @OneToMany(mappedBy = "competition", cascade = CascadeType.ALL)
+//    private List<BaseCareerDetail> detailList = new ArrayList<>();
     @Override
     public Long getId() {
         return id;

--- a/src/main/java/umc/kkijuk/server/career/domain/EduCareer.java
+++ b/src/main/java/umc/kkijuk/server/career/domain/EduCareer.java
@@ -19,8 +19,8 @@ public class EduCareer extends BaseCareer {
     private String organizer;
     private int time;
 
-    @OneToMany(mappedBy = "eduCareer", cascade = CascadeType.ALL)
-    private List<BaseCareerDetail> detailList = new ArrayList<>();
+//    @OneToMany(mappedBy = "eduCareer", cascade = CascadeType.ALL)
+//    private List<BaseCareerDetail> detailList = new ArrayList<>();
     @Override
     public Long getId() {
         return id;

--- a/src/main/java/umc/kkijuk/server/career/domain/Employment.java
+++ b/src/main/java/umc/kkijuk/server/career/domain/Employment.java
@@ -20,8 +20,8 @@ public class Employment extends BaseCareer{
     private String position;
     private String field;
 
-    @OneToMany(mappedBy = "employment", cascade = CascadeType.ALL)
-    private List<BaseCareerDetail> detailList = new ArrayList<>();
+//    @OneToMany(mappedBy = "employment", cascade = CascadeType.ALL)
+//    private List<BaseCareerDetail> detailList = new ArrayList<>();
     @Override
     public Long getId() {
         return id;

--- a/src/main/java/umc/kkijuk/server/career/domain/Project.java
+++ b/src/main/java/umc/kkijuk/server/career/domain/Project.java
@@ -21,8 +21,8 @@ public class Project extends BaseCareer{
     @Enumerated(EnumType.STRING)
     private ProjectType location;
 
-    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
-    private List<BaseCareerDetail> detailList = new ArrayList<>();
+//    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
+//    private List<BaseCareerDetail> detailList = new ArrayList<>();
     @Override
     public Long getId() {
         return id;

--- a/src/main/java/umc/kkijuk/server/career/dto/EtcReqDto.java
+++ b/src/main/java/umc/kkijuk/server/career/dto/EtcReqDto.java
@@ -1,0 +1,43 @@
+package umc.kkijuk.server.career.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EtcReqDto {
+    @NotBlank(message = "활동명은 필수 입력 항목입니다. 최대 20자 까지 입력 가능")
+    @Size(max = 20)
+    @Schema(description = "활동명", example = "학원 채점 아르바이트", type="string")
+    private String name;
+
+    @NotBlank(message = "활동 별칭은 필수 입력 항목입니다. 최대 20자 까지 입력 가능")
+    @Size(max = 20)
+    @Schema(description = "활동 별칭", example = "UMC", type="string")
+    private String alias;
+
+    @NotNull(message = "활동 기간을 알고 있는지 여부를 나타냅니다.")
+    @Schema(description = "활동 기간 인지 여부", example = "false", type = "boolean")
+    private Boolean unknown;
+
+    @NotNull(message = "활동 시작 날짜는 필수 입력 항목입니다.")
+    @JsonFormat(shape=JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    @Schema(description = "활동 시작 날짜", example = "2024-04-14", type="string")
+    private LocalDate startdate;
+
+    @JsonFormat(shape=JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    @Schema(description = "활동 종료 날짜", example = "2024-07-20", type = "string")
+    private LocalDate enddate;
+
+}

--- a/src/main/java/umc/kkijuk/server/career/dto/converter/BaseCareerConverter.java
+++ b/src/main/java/umc/kkijuk/server/career/dto/converter/BaseCareerConverter.java
@@ -89,4 +89,14 @@ public class BaseCareerConverter {
                 .role(circleReqDto.getRole()).build();
     }
 
+    public static CareerEtc toEtc(Member requestMember, EtcReqDto etcReqDto) {
+        return CareerEtc.builder()
+                .memberId(requestMember.getId())
+                .name(etcReqDto.getName())
+                .alias(etcReqDto.getAlias())
+                .unknown(etcReqDto.getUnknown())
+                .startdate(etcReqDto.getStartdate())
+                .enddate(etcReqDto.getEnddate())
+                .build();
+    }
 }

--- a/src/main/java/umc/kkijuk/server/career/repository/CareerEtcRepository.java
+++ b/src/main/java/umc/kkijuk/server/career/repository/CareerEtcRepository.java
@@ -1,0 +1,7 @@
+package umc.kkijuk.server.career.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.kkijuk.server.career.domain.CareerEtc;
+
+public interface CareerEtcRepository extends JpaRepository<CareerEtc,Long> {
+}

--- a/src/main/java/umc/kkijuk/server/career/repository/CareerEtcRepository.java
+++ b/src/main/java/umc/kkijuk/server/career/repository/CareerEtcRepository.java
@@ -3,5 +3,10 @@ package umc.kkijuk.server.career.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.kkijuk.server.career.domain.CareerEtc;
 
+import java.util.List;
+
 public interface CareerEtcRepository extends JpaRepository<CareerEtc,Long> {
+    List<CareerEtc> findByMemberId(Long memberId);
+
+    List<CareerEtc> findByMemberIdAndNameContaining(Long id, String keyword);
 }

--- a/src/main/java/umc/kkijuk/server/career/service/BaseCareerService.java
+++ b/src/main/java/umc/kkijuk/server/career/service/BaseCareerService.java
@@ -19,6 +19,7 @@ public interface BaseCareerService {
     EmploymentResponse createEmployment(Member requestMember, EmploymentReqDto employmentReqDto);
 
     ProjectResponse createProject(Member requestMember, ProjectReqDto projectReqDto);
+    EtcResponse createEtc(Member requestMember, EtcReqDto etcReqDto);
 
     void deleteActivity(Member requestMember, Long activityId);
 
@@ -31,6 +32,7 @@ public interface BaseCareerService {
     void deleteEmp(Member requestMember, Long employmentId);
 
     void deleteProject(Member requestMember, Long projectId);
+    void deleteEtc(Member requestMember, Long etcId);
 
     ActivityResponse updateActivity(Member requestMember, Long activityId, ActivityReqDto request);
 
@@ -41,6 +43,7 @@ public interface BaseCareerService {
     EduCareerResponse updateEdu(Member requestMember, Long educareerId, EduCareerReqDto eduCareerReqDto);
 
     EmploymentResponse updateEmp(Member requestMember, Long employmentId, EmploymentReqDto employmentReqDto);
+    EtcResponse updateEtc(Member requestMember, Long etcId, EtcReqDto etcReqDto);
 
     ProjectResponse updateProject(Member requestMember, Long projectId, ProjectReqDto projectReqDto);
 

--- a/src/main/java/umc/kkijuk/server/career/service/CareerSearchService.java
+++ b/src/main/java/umc/kkijuk/server/career/service/CareerSearchService.java
@@ -1,0 +1,23 @@
+package umc.kkijuk.server.career.service;
+
+import umc.kkijuk.server.career.controller.response.*;
+import umc.kkijuk.server.member.domain.Member;
+
+import java.util.List;
+import java.util.Map;
+
+public interface CareerSearchService {
+    List<TimelineResponse> findCareerForTimeline(Member requestMember);
+    Map<String, List<?>> findAllCareerGroupedCategory(Long memberId);
+    Map<String, List<?>> findAllCareerGroupedYear(Long memberId);
+    List<BaseCareerResponse> findAllCareer(Long memberId);
+    BaseCareerResponse findCareer(Member requestMember, Long careerId, String type);
+    List<FindDetailResponse> findAllDetail(Member requestMember, String keyword, String sort);
+
+    List<FindTagResponse> findAllTag(Member requestMember, String keyword);
+
+    List<FindDetailResponse> findAllDetailByTag(Member requestMember, Long tagId, String sort);
+
+    List<FindCareerResponse> findCareerWithKeyword(Member requestMember, String keyword, String sort);
+
+}

--- a/src/main/java/umc/kkijuk/server/career/service/CareerSearchServiceImpl.java
+++ b/src/main/java/umc/kkijuk/server/career/service/CareerSearchServiceImpl.java
@@ -1,0 +1,435 @@
+package umc.kkijuk.server.career.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import umc.kkijuk.server.career.controller.response.*;
+import umc.kkijuk.server.career.domain.*;
+import umc.kkijuk.server.career.repository.*;
+import umc.kkijuk.server.common.domian.exception.OwnerMismatchException;
+import umc.kkijuk.server.detail.controller.response.BaseCareerDetailResponse;
+import umc.kkijuk.server.detail.domain.BaseCareerDetail;
+import umc.kkijuk.server.detail.domain.CareerType;
+import umc.kkijuk.server.detail.repository.BaseCareerDetailRepository;
+import umc.kkijuk.server.member.domain.Member;
+import umc.kkijuk.server.tag.domain.Tag;
+import umc.kkijuk.server.tag.repository.TagRepository;
+
+import java.time.LocalDate;
+import java.util.*;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CareerSearchServiceImpl implements CareerSearchService{
+    private final ActivityRepository activityRepository;
+    private final CircleRepository circleRepository;
+    private final CompetitionRepository competitionRepository;
+    private final EduCareerRepository eduCareerRepository;
+    private final ProjectRepository projectRepository;
+    private final EmploymentRepository employmentRepository;
+    private final CareerEtcRepository etcRepository;
+    private final BaseCareerDetailRepository detailRepository;
+    private final TagRepository tagRepository;
+
+    @Override
+    public List<TimelineResponse> findCareerForTimeline(Member requestMember) {
+        Long memberId = requestMember.getId();
+        List<BaseCareer> careers = new ArrayList<>();
+
+
+        careers.addAll(activityRepository.findByMemberId(memberId));
+        careers.addAll(eduCareerRepository.findByMemberId(memberId));
+        careers.addAll(employmentRepository.findByMemberId(memberId));
+        careers.addAll(circleRepository.findByMemberId(memberId));
+        careers.addAll(projectRepository.findByMemberId(memberId));
+        careers.addAll(competitionRepository.findByMemberId(memberId));
+        careers.addAll(etcRepository.findByMemberId(memberId));
+
+
+        careers.sort(Comparator.comparing(BaseCareer::getEnddate).reversed());
+
+        return careers.stream()
+                .map(career -> new TimelineResponse(career, resolveCareerType(career)))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Map<String, List<?>> findAllCareerGroupedCategory(Long memberId) {
+        List<EduCareerResponse> eduCareers = eduCareerRepository.findByMemberId(memberId)
+                .stream().map(EduCareerResponse::new).collect(Collectors.toList());
+        List<EmploymentResponse> employments = employmentRepository.findByMemberId(memberId)
+                .stream().map(EmploymentResponse::new).collect(Collectors.toList());
+        List<ProjectResponse> projects = projectRepository.findByMemberId(memberId)
+                .stream().map(ProjectResponse::new).collect(Collectors.toList());
+        List<ActivityResponse> activities = activityRepository.findByMemberId(memberId)
+                .stream().map(ActivityResponse::new).collect(Collectors.toList());
+        List<CircleResponse> circles = circleRepository.findByMemberId(memberId)
+                .stream().map(CircleResponse::new).collect(Collectors.toList());
+        List<CompetitionResponse> competitions = competitionRepository.findByMemberId(memberId)
+                .stream().map(CompetitionResponse::new).collect(Collectors.toList());
+        List<EtcResponse> etcs = etcRepository.findByMemberId(memberId)
+                .stream().map(EtcResponse::new).collect(Collectors.toList());
+
+
+        Map<String, List<?>> careerList = new HashMap<>();
+        careerList.put("대외활동",activities);
+        careerList.put("동아리",circles);
+        careerList.put("대회",competitions);
+        careerList.put("교육",eduCareers);
+        careerList.put("인턴",employments);
+        careerList.put("프로젝트",projects);
+        careerList.put("기타", etcs);
+
+        return careerList;
+    }
+
+    @Override
+    public Map<String, List<?>> findAllCareerGroupedYear(Long memberId) {
+        List<BaseCareerResponse> baseCareers = projectRepository.findByMemberId(memberId).stream()
+                .map(ProjectResponse::new)
+                .collect(Collectors.toList());
+        baseCareers.addAll(competitionRepository.findByMemberId(memberId).stream()
+                .map(CompetitionResponse::new).collect(Collectors.toList()));
+        baseCareers.addAll(activityRepository.findByMemberId(memberId).stream()
+                .map(ActivityResponse::new).collect(Collectors.toList()));
+        baseCareers.addAll(circleRepository.findByMemberId(memberId).stream()
+                .map(CircleResponse::new).collect(Collectors.toList()));
+        baseCareers.addAll(eduCareerRepository.findByMemberId(memberId).stream()
+                .map(EduCareerResponse::new).collect(Collectors.toList()));
+        baseCareers.addAll(employmentRepository.findByMemberId(memberId).stream()
+                .map(EmploymentResponse::new).collect(Collectors.toList()));
+        baseCareers.addAll(etcRepository.findByMemberId(memberId).stream()
+                .map(EtcResponse::new).collect(Collectors.toList()));
+
+
+//        baseCareers.stream().sorted(Comparator.comparing(BaseCareerResponse::getEndDate).reversed());
+
+        baseCareers = baseCareers.stream()
+                .sorted(Comparator.comparing(BaseCareerResponse::getEndDate).reversed())
+                .collect(Collectors.toList());
+
+
+        Map<String, List<BaseCareerResponse>> groupedCareers = baseCareers.stream()
+                .collect(Collectors.groupingBy(
+                        career -> String.valueOf(career.getEndDate().getYear())
+                ));
+
+
+        Map<String, List<?>> result = new HashMap<>();
+        for (Map.Entry<String, List<BaseCareerResponse>> entry : groupedCareers.entrySet()) {
+            List<?> filteredList = entry.getValue().stream()
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+            result.put(entry.getKey(), filteredList);
+        }
+        return result;
+    }
+
+    @Override
+    public List<BaseCareerResponse> findAllCareer(Long memberId) {
+        List<BaseCareerResponse> baseCareers = projectRepository.findByMemberId(memberId).stream()
+                .map(project-> new ProjectResponse(project,detailRepository.findByProject(project)))
+                .collect(Collectors.toList());
+        baseCareers.addAll(competitionRepository.findByMemberId(memberId).stream()
+                .map(comp-> new CompetitionResponse(comp, detailRepository.findByCompetition(comp)))
+                .collect(Collectors.toList()));
+        baseCareers.addAll(activityRepository.findByMemberId(memberId).stream()
+                .map(activity->new ActivityResponse(activity, detailRepository.findByActivity(activity)))
+                .collect(Collectors.toList()));
+        baseCareers.addAll(circleRepository.findByMemberId(memberId).stream()
+                .map(circle-> new CircleResponse(circle, detailRepository.findByCircle(circle)))
+                .collect(Collectors.toList()));
+        baseCareers.addAll(eduCareerRepository.findByMemberId(memberId).stream()
+                .map(eduCareer -> new EduCareerResponse(eduCareer, detailRepository.findByEduCareer(eduCareer)))
+                .collect(Collectors.toList()));
+        baseCareers.addAll(employmentRepository.findByMemberId(memberId).stream()
+                .map(employment -> new EmploymentResponse(employment, detailRepository.findByEmployment(employment)))
+                .collect(Collectors.toList()));
+
+        baseCareers.addAll(etcRepository.findByMemberId(memberId).stream()
+                .map(etc -> new EtcResponse(etc, detailRepository.findByEtc(etc)))
+                .collect(Collectors.toList()));
+
+        baseCareers = baseCareers.stream()
+                .sorted(Comparator.comparing(BaseCareerResponse::getEndDate).reversed())
+                .collect(Collectors.toList());
+
+        return baseCareers;
+    }
+    @Override
+    public BaseCareerResponse findCareer(Member requestMember, Long careerId, String type) {
+        switch (type.toLowerCase()) {
+            case "activity" -> {
+                Activity activity = activityRepository.findById(careerId).get();
+                if(!activity.getMemberId().equals(requestMember.getId())){
+                    throw new OwnerMismatchException();
+                }
+                return getResponse(activity, ActivityResponse::new);
+            }
+            case "circle"  -> {
+                Circle circle = circleRepository.findById(careerId).get();
+                if(!circle.getMemberId().equals(requestMember.getId())){
+                    throw new OwnerMismatchException();
+                }
+                return getResponse(circle, CircleResponse::new);
+            }
+            case "project"  -> {
+                Project project = projectRepository.findById(careerId).get();
+                if(!project.getMemberId().equals(requestMember.getId())){
+                    throw new OwnerMismatchException();
+                }
+                return getResponse(project, ProjectResponse::new);
+            }
+            case "edu"  -> {
+                EduCareer eduCareer = eduCareerRepository.findById(careerId).get();
+                if(!eduCareer.getMemberId().equals(requestMember.getId())){
+                    throw new OwnerMismatchException();
+                }
+                return getResponse(eduCareer, EduCareerResponse::new);
+            }
+            case "competition"  -> {
+                Competition competition = competitionRepository.findById(careerId).get();
+                if(!competition.getMemberId().equals(requestMember.getId())){
+                    throw new OwnerMismatchException();
+                }
+                return getResponse(competition, CompetitionResponse::new);
+            }
+            case "employment"  -> {
+                Employment employment = employmentRepository.findById(careerId).get();
+                if(!employment.getMemberId().equals(requestMember.getId())){
+                    throw new OwnerMismatchException();
+                }
+                return getResponse(employment, EmploymentResponse::new);
+            }
+            case "etc"  -> {
+                CareerEtc etc = etcRepository.findById(careerId).get();
+                if(!etc.getMemberId().equals(requestMember.getId())){
+                    throw new OwnerMismatchException();
+                }
+                return getResponse(etc, EtcResponse::new);
+            }
+            default -> throw new IllegalArgumentException("지원하지 않는 활동 유형입니다 : " + type);
+        }
+    }
+
+    @Override
+    public List<FindTagResponse> findAllTag(Member requestMember, String keyword) {
+        List<Tag> tags = tagRepository.findByKeywordAndMemberId(keyword, requestMember.getId());
+        return tags.stream().map(FindTagResponse::new).collect(Collectors.toList());
+    }
+    @Override
+    public List<FindDetailResponse> findAllDetail(Member requestMember, String keyword, String sort) {
+        List<BaseCareerDetail> detailList = detailRepository.findByMemberIdAndKeyword(requestMember.getId(), keyword);
+        return buildDetailResponse(detailList, sort);
+    }
+
+    @Override
+    public List<FindDetailResponse> findAllDetailByTag(Member requestMember, Long tagId, String sort) {
+        Tag tag = tagRepository.findById(tagId).get();
+        if (!tag.getMemberId().equals(requestMember.getId())) {
+            throw new OwnerMismatchException();
+        }
+        List<BaseCareerDetail> detailList = detailRepository.findByTag(tag.getId());
+        return buildDetailResponse(detailList, sort);
+    }
+
+    @Override
+    public List<FindCareerResponse> findCareerWithKeyword(Member requestMember, String keyword, String sort) {
+        List<BaseCareer> careers = new ArrayList<>();
+        careers.addAll(activityRepository.findByMemberIdAndNameContaining(requestMember.getId(),keyword));
+        careers.addAll(eduCareerRepository.findByMemberIdAndNameContaining(requestMember.getId(),keyword));
+        careers.addAll(employmentRepository.findByMemberIdAndNameContaining(requestMember.getId(),keyword));
+        careers.addAll(circleRepository.findByMemberIdAndNameContaining(requestMember.getId(),keyword));
+        careers.addAll(projectRepository.findByMemberIdAndNameContaining(requestMember.getId(),keyword));
+        careers.addAll(competitionRepository.findByMemberIdAndNameContaining(requestMember.getId(),keyword));
+        careers.addAll(etcRepository.findByMemberIdAndNameContaining(requestMember.getId(),keyword));
+
+        if ("new".equalsIgnoreCase(sort)) {
+            careers.sort(Comparator.comparing(BaseCareer::getEnddate).reversed());
+        } else {
+            careers.sort(Comparator.comparing(BaseCareer::getEnddate));
+        }
+
+        return careers.stream().limit(2)
+                .map(career -> new FindCareerResponse(career, career.getClass().getSimpleName()))
+                .collect(Collectors.toList());
+
+    }
+
+
+
+
+    //타임라인 쪽에서 데이터 구별 하기 위함
+    private CareerType resolveCareerType(BaseCareer career) {
+        if (career instanceof Activity) {
+            return CareerType.ACTIVITY;
+        } else if (career instanceof Project) {
+            return CareerType.PROJECT;
+        } else if (career instanceof Employment) {
+            return CareerType.EMP;
+        } else if (career instanceof EduCareer) {
+            return CareerType.EDU;
+        } else if (career instanceof Circle) {
+            return CareerType.CIRCLE;
+        } else if (career instanceof Competition) {
+            return CareerType.COM;
+        } else {
+            return CareerType.ETC;
+        }
+    }
+    //활동 기록 상세조회에서 사용
+    private <T extends BaseCareer, R extends BaseCareerResponse> R getResponse(T career,  BiFunction<T, List<BaseCareerDetail>, R> responseConstructor) {
+        List<BaseCareerDetail> details;
+        if (career instanceof Activity) {
+            details = Optional.ofNullable(detailRepository.findByActivity((Activity) career))
+                    .orElseGet(Collections::emptyList);
+        } else if (career instanceof Circle) {
+            details = Optional.ofNullable(detailRepository.findByCircle((Circle) career))
+                    .orElseGet(Collections::emptyList);
+        } else if (career instanceof Competition) {
+            details = Optional.ofNullable(detailRepository.findByCompetition((Competition) career))
+                    .orElseGet(Collections::emptyList);
+        } else if (career instanceof EduCareer) {
+            details =Optional.ofNullable(detailRepository.findByEduCareer((EduCareer) career))
+                    .orElseGet(Collections::emptyList);
+        } else if (career instanceof Employment) {
+            details = Optional.ofNullable( detailRepository.findByEmployment((Employment) career))
+                    .orElseGet(Collections::emptyList);
+        } else if (career instanceof Project) {
+            details = Optional.ofNullable( detailRepository.findByProject((Project) career))
+                    .orElseGet(Collections::emptyList);
+        } else if (career instanceof CareerEtc) {
+            details = Optional.ofNullable( detailRepository.findByEtc((CareerEtc) career))
+                    .orElseGet(Collections::emptyList);
+        }
+        else {
+            throw new IllegalArgumentException("지원하지 않는 타입입니다.");
+        }
+        return responseConstructor.apply(career,details);
+    }
+    private List<FindDetailResponse> buildDetailResponse(List<BaseCareerDetail> detailList, String sort) {
+        Map<String, Map<Long, List<BaseCareerDetail>>> groupedDetails = new HashMap<>();
+        for (BaseCareerDetail detail : detailList) {
+            String careerType = getCareerType(detail);
+            Long careerId = getCareerId(detail);
+            groupedDetails
+                    .computeIfAbsent(careerType, k -> new HashMap<>())
+                    .computeIfAbsent(careerId, k -> new ArrayList<>())
+                    .add(detail);
+        }
+
+        List<FindDetailResponse> result = new ArrayList<>();
+
+        for(Map.Entry<String, Map<Long, List<BaseCareerDetail>>> entry : groupedDetails.entrySet()) {
+            String type = entry.getKey();
+            Map<Long, List<BaseCareerDetail>> careerMap = entry.getValue();
+
+            for(Map.Entry<Long,List<BaseCareerDetail>> careerEntry : careerMap.entrySet()){
+                Long careerId = careerEntry.getKey();
+                List<BaseCareerDetail> details = careerEntry.getValue();
+                List<BaseCareerDetailResponse> detailResponses = new ArrayList<>();
+                CareerSearchServiceImpl.FindDetailInfo detailInfo = extractDetailInfo(details);
+
+                for (BaseCareerDetail detail: details) {
+                    detailResponses.add(new BaseCareerDetailResponse(detail));
+                }
+
+                result.add(new FindDetailResponse(careerId,type,detailInfo.title,detailInfo.alias,detailInfo.startDate,detailInfo.endDate,detailResponses));
+            }
+        }
+        if (sort.equals("new")) {
+            result.stream().sorted(Comparator.comparing(FindDetailResponse::getEndDate).reversed());
+        } else {
+            result.stream().sorted(Comparator.comparing(FindDetailResponse::getEndDate).reversed());
+        }
+        return result;
+
+    }
+
+    private String getCareerType(BaseCareerDetail detail) {
+        switch (detail.getCareerType()) {
+            case ACTIVITY: return CareerType.ACTIVITY.getDescription();
+            case PROJECT: return CareerType.PROJECT.getDescription();
+            case EMP: return CareerType.EMP.getDescription();
+            case EDU: return CareerType.EDU.getDescription();
+            case COM: return CareerType.COM.getDescription();
+            case CIRCLE: return CareerType.CIRCLE.getDescription();
+            case ETC:return CareerType.ETC.getDescription();
+            default: return null;
+        }
+    }
+    private Long getCareerId(BaseCareerDetail detail) {
+        switch (detail.getCareerType()) {
+            case ACTIVITY: return detail.getActivity().getId();
+            case PROJECT: return detail.getProject().getId();
+            case EMP: return detail.getEmployment().getId();
+            case EDU: return detail.getEduCareer().getId();
+            case COM: return detail.getCompetition().getId();
+            case CIRCLE: return detail.getCircle().getId();
+            case ETC: return detail.getEtc().getId();
+            default: return null;
+        }
+    }
+    private CareerSearchServiceImpl.FindDetailInfo extractDetailInfo(List<BaseCareerDetail> details) {
+        if (details.isEmpty()) {
+            return new CareerSearchServiceImpl.FindDetailInfo(null, null, null, null);
+        }
+
+        BaseCareerDetail firstDetail = details.get(0);
+        String title = null;
+        String alias = null;
+        LocalDate startDate = null;
+        LocalDate endDate = null;
+
+        switch (firstDetail.getCareerType()) {
+            case ACTIVITY -> {
+                title = firstDetail.getActivity().getName();
+                alias = firstDetail.getActivity().getAlias();
+            }
+            case PROJECT -> {
+                title = firstDetail.getProject().getName();
+                alias = firstDetail.getProject().getAlias();
+            }
+            case EMP -> {
+                title = firstDetail.getEmployment().getName();
+                alias = firstDetail.getEmployment().getAlias();
+            }
+            case EDU -> {
+                title = firstDetail.getEduCareer().getName();
+                alias = firstDetail.getEduCareer().getAlias();
+            }
+            case COM -> {
+                title = firstDetail.getCompetition().getName();
+                alias = firstDetail.getCompetition().getAlias();
+            }
+            case CIRCLE -> {
+                title = firstDetail.getCircle().getName();
+                alias = firstDetail.getCircle().getAlias();
+            }
+            case ETC -> {
+                title = firstDetail.getEtc().getName();
+                alias = firstDetail.getEtc().getAlias();
+            }
+        }
+
+        startDate = firstDetail.getStartDate();
+        endDate = firstDetail.getEndDate();
+
+        return new CareerSearchServiceImpl.FindDetailInfo(title, alias, startDate, endDate);
+    }
+    private static class FindDetailInfo {
+        String title;
+        String alias;
+        LocalDate startDate;
+        LocalDate endDate;
+
+        FindDetailInfo(String title, String alias, LocalDate startDate, LocalDate endDate) {
+            this.title = title;
+            this.alias = alias;
+            this.startDate = startDate;
+            this.endDate = endDate;
+        }
+    }
+
+}

--- a/src/main/java/umc/kkijuk/server/career/service/CareerService.java
+++ b/src/main/java/umc/kkijuk/server/career/service/CareerService.java
@@ -7,7 +7,7 @@ import umc.kkijuk.server.member.domain.Member;
 import java.util.List;
 import java.util.Map;
 
-public interface BaseCareerService {
+public interface CareerService {
     ActivityResponse createActivity(Member requestMember, ActivityReqDto activityReqDto);
 
     CircleResponse createCircle(Member requestMember, CircleReqDto circleReqDto);
@@ -48,21 +48,22 @@ public interface BaseCareerService {
     ProjectResponse updateProject(Member requestMember, Long projectId, ProjectReqDto projectReqDto);
 
     void deleteBaseCareer(Member requestMember, Long careerId, String type);
-    Map<String, List<?>>  findAllCareerGroupedCategory(Long id);
-    Map<String, List<?>> findAllCareerGroupedYear(Long id);
-
-    BaseCareerResponse findCareer(Member requestMember, Long careerId, String type);
-
     BaseCareerResponse createSummary(Member requestMember, Long careerId, CareerSummaryReqDto request);
-    List<FindDetailResponse> findAllDetail(Member requestMember, String keyword, String sort);
 
-    List<FindTagResponse> findAllTag(Member requestMember, String keyword);
+//    Map<String, List<?>>  findAllCareerGroupedCategory(Long id);
+//    Map<String, List<?>> findAllCareerGroupedYear(Long id);
 
-    List<FindDetailResponse> findAllDetailByTag(Member requestMember, Long tagId, String sort);
+//    BaseCareerResponse findCareer(Member requestMember, Long careerId, String type);
 
-    List<FindCareerResponse> findCareerWithKeyword(Member requestMember, String keyword, String sort);
+//    List<FindDetailResponse> findAllDetail(Member requestMember, String keyword, String sort);
+//
+//    List<FindTagResponse> findAllTag(Member requestMember, String keyword);
+//
+//    List<FindDetailResponse> findAllDetailByTag(Member requestMember, Long tagId, String sort);
+//
+//    List<FindCareerResponse> findCareerWithKeyword(Member requestMember, String keyword, String sort);
 
-    List<TimelineResponse> findCareerForTimeline(Member requestMember);
+//    List<TimelineResponse> findCareerForTimeline(Member requestMember);
 
-    List<BaseCareerResponse> findAllCareer(Long memberId);
+//    List<BaseCareerResponse> findAllCareer(Long memberId);
 }

--- a/src/main/java/umc/kkijuk/server/career/service/CareerServiceImpl.java
+++ b/src/main/java/umc/kkijuk/server/career/service/CareerServiceImpl.java
@@ -10,22 +10,17 @@ import umc.kkijuk.server.career.dto.converter.BaseCareerConverter;
 import umc.kkijuk.server.career.repository.*;
 import umc.kkijuk.server.common.domian.exception.OwnerMismatchException;
 import umc.kkijuk.server.common.domian.exception.ResourceNotFoundException;
-import umc.kkijuk.server.detail.controller.response.BaseCareerDetailResponse;
 import umc.kkijuk.server.detail.domain.BaseCareerDetail;
-import umc.kkijuk.server.detail.domain.CareerType;
 import umc.kkijuk.server.detail.repository.BaseCareerDetailRepository;
 import umc.kkijuk.server.member.domain.Member;
-import umc.kkijuk.server.tag.domain.Tag;
-import umc.kkijuk.server.tag.repository.TagRepository;
 
 import java.time.LocalDate;
 import java.util.*;
 import java.util.function.BiFunction;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-public class BaseCareerServiceImpl implements BaseCareerService{
+public class CareerServiceImpl implements CareerService{
     private final ActivityRepository activityRepository;
     private final CircleRepository circleRepository;
     private final CompetitionRepository competitionRepository;
@@ -33,7 +28,6 @@ public class BaseCareerServiceImpl implements BaseCareerService{
     private final ProjectRepository projectRepository;
     private final EmploymentRepository employmentRepository;
     private final BaseCareerDetailRepository detailRepository;
-    private final TagRepository tagRepository;
     private final CareerEtcRepository etcRepository;
 
     @Override
@@ -346,148 +340,6 @@ public class BaseCareerServiceImpl implements BaseCareerService{
     }
 
     @Override
-    public Map<String, List<?>> findAllCareerGroupedCategory(Long memberId) {
-        List<EduCareerResponse> eduCareers = eduCareerRepository.findByMemberId(memberId)
-                .stream().map(EduCareerResponse::new).collect(Collectors.toList());
-        List<EmploymentResponse> employments = employmentRepository.findByMemberId(memberId)
-                .stream().map(EmploymentResponse::new).collect(Collectors.toList());
-        List<ProjectResponse> projects = projectRepository.findByMemberId(memberId)
-                .stream().map(ProjectResponse::new).collect(Collectors.toList());
-        List<ActivityResponse> activities = activityRepository.findByMemberId(memberId)
-                .stream().map(ActivityResponse::new).collect(Collectors.toList());
-        List<CircleResponse> circles = circleRepository.findByMemberId(memberId)
-                .stream().map(CircleResponse::new).collect(Collectors.toList());
-        List<CompetitionResponse> competitions = competitionRepository.findByMemberId(memberId)
-                .stream().map(CompetitionResponse::new).collect(Collectors.toList());
-
-
-        Map<String, List<?>> careerList = new HashMap<>();
-        careerList.put("대외활동",activities);
-        careerList.put("동아리",circles);
-        careerList.put("대회",competitions);
-        careerList.put("교육",eduCareers);
-        careerList.put("인턴",employments);
-        careerList.put("프로젝트",projects);
-        return careerList;
-    }
-
-    @Override
-    public Map<String, List<?>> findAllCareerGroupedYear(Long memberId) {
-        List<BaseCareerResponse> baseCareers = projectRepository.findByMemberId(memberId).stream()
-                .map(ProjectResponse::new)
-                .collect(Collectors.toList());
-        baseCareers.addAll(competitionRepository.findByMemberId(memberId).stream()
-                .map(CompetitionResponse::new).collect(Collectors.toList()));
-        baseCareers.addAll(activityRepository.findByMemberId(memberId).stream()
-                .map(ActivityResponse::new).collect(Collectors.toList()));
-        baseCareers.addAll(circleRepository.findByMemberId(memberId).stream()
-                .map(CircleResponse::new).collect(Collectors.toList()));
-        baseCareers.addAll(eduCareerRepository.findByMemberId(memberId).stream()
-                .map(EduCareerResponse::new).collect(Collectors.toList()));
-        baseCareers.addAll(employmentRepository.findByMemberId(memberId).stream()
-                .map(EmploymentResponse::new).collect(Collectors.toList()));
-
-
-//        baseCareers.stream().sorted(Comparator.comparing(BaseCareerResponse::getEndDate).reversed());
-
-        baseCareers = baseCareers.stream()
-                .sorted(Comparator.comparing(BaseCareerResponse::getEndDate).reversed())
-                .collect(Collectors.toList());
-
-
-        Map<String, List<BaseCareerResponse>> groupedCareers = baseCareers.stream()
-                .collect(Collectors.groupingBy(
-                        career -> String.valueOf(career.getEndDate().getYear())
-                ));
-
-
-        Map<String, List<?>> result = new HashMap<>();
-        for (Map.Entry<String, List<BaseCareerResponse>> entry : groupedCareers.entrySet()) {
-            List<?> filteredList = entry.getValue().stream()
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toList());
-            result.put(entry.getKey(), filteredList);
-        }
-        return result;
-    }
-
-
-    @Override
-    public List<BaseCareerResponse> findAllCareer(Long memberId) {
-        List<BaseCareerResponse> baseCareers = projectRepository.findByMemberId(memberId).stream()
-                .map(project-> new ProjectResponse(project,detailRepository.findByProject(project)))
-                .collect(Collectors.toList());
-        baseCareers.addAll(competitionRepository.findByMemberId(memberId).stream()
-                .map(comp-> new CompetitionResponse(comp, detailRepository.findByCompetition(comp)))
-                .collect(Collectors.toList()));
-        baseCareers.addAll(activityRepository.findByMemberId(memberId).stream()
-                .map(activity->new ActivityResponse(activity, detailRepository.findByActivity(activity)))
-                .collect(Collectors.toList()));
-        baseCareers.addAll(circleRepository.findByMemberId(memberId).stream()
-                .map(circle-> new CircleResponse(circle, detailRepository.findByCircle(circle)))
-                .collect(Collectors.toList()));
-        baseCareers.addAll(eduCareerRepository.findByMemberId(memberId).stream()
-                .map(eduCareer -> new EduCareerResponse(eduCareer, detailRepository.findByEduCareer(eduCareer)))
-                .collect(Collectors.toList()));
-        baseCareers.addAll(employmentRepository.findByMemberId(memberId).stream()
-                .map(employment -> new EmploymentResponse(employment, detailRepository.findByEmployment(employment)))
-                .collect(Collectors.toList()));
-
-        baseCareers = baseCareers.stream()
-                .sorted(Comparator.comparing(BaseCareerResponse::getEndDate).reversed())
-                .collect(Collectors.toList());
-        return baseCareers;
-    }
-
-    @Override
-    public BaseCareerResponse findCareer(Member requestMember, Long careerId, String type) {
-        switch (type.toLowerCase()) {
-            case "activity" -> {
-                Activity activity = activityRepository.findById(careerId).get();
-                if(!activity.getMemberId().equals(requestMember.getId())){
-                    throw new OwnerMismatchException();
-                }
-                return getResponse(activity, ActivityResponse::new);
-            }
-            case "circle"  -> {
-                Circle circle = circleRepository.findById(careerId).get();
-                if(!circle.getMemberId().equals(requestMember.getId())){
-                    throw new OwnerMismatchException();
-                }
-                return getResponse(circle, CircleResponse::new);
-            }
-            case "project"  -> {
-                Project project = projectRepository.findById(careerId).get();
-                if(!project.getMemberId().equals(requestMember.getId())){
-                    throw new OwnerMismatchException();
-                }
-                return getResponse(project, ProjectResponse::new);
-            }
-            case "edu"  -> {
-                EduCareer eduCareer = eduCareerRepository.findById(careerId).get();
-                if(!eduCareer.getMemberId().equals(requestMember.getId())){
-                    throw new OwnerMismatchException();
-                }
-                return getResponse(eduCareer, EduCareerResponse::new);
-            }
-            case "competition"  -> {
-                Competition competition = competitionRepository.findById(careerId).get();
-                if(!competition.getMemberId().equals(requestMember.getId())){
-                    throw new OwnerMismatchException();
-                }
-                return getResponse(competition, CompetitionResponse::new);
-            }
-            case "employment"  -> {
-                Employment employment = employmentRepository.findById(careerId).get();
-                if(!employment.getMemberId().equals(requestMember.getId())){
-                    throw new OwnerMismatchException();
-                }
-                return getResponse(employment, EmploymentResponse::new);
-            }
-            default -> throw new IllegalArgumentException("지원하지 않는 활동 유형입니다 : " + type);
-        }
-    }
-    @Override
     @Transactional
     public BaseCareerResponse createSummary(Member requestMember, Long careerId, CareerSummaryReqDto request) {
         switch (request.getType()){
@@ -550,192 +402,6 @@ public class BaseCareerServiceImpl implements BaseCareerService{
 
         }
     }
-    @Override
-    public List<FindTagResponse> findAllTag(Member requestMember, String keyword) {
-        List<Tag> tags = tagRepository.findByKeywordAndMemberId(keyword, requestMember.getId());
-        return tags.stream().map(FindTagResponse::new).collect(Collectors.toList());
-    }
-    @Override
-    public List<FindDetailResponse> findAllDetail(Member requestMember, String keyword, String sort) {
-        List<BaseCareerDetail> detailList = detailRepository.findByMemberIdAndKeyword(requestMember.getId(), keyword);
-        return buildDetailResponse(detailList, sort);
-    }
-
-    @Override
-    public List<FindDetailResponse> findAllDetailByTag(Member requestMember, Long tagId, String sort) {
-        Tag tag = tagRepository.findById(tagId).get();
-        if (!tag.getMemberId().equals(requestMember.getId())) {
-            throw new OwnerMismatchException();
-        }
-        List<BaseCareerDetail> detailList = detailRepository.findByTag(tag.getId());
-        return buildDetailResponse(detailList, sort);
-    }
-
-    @Override
-    public List<FindCareerResponse> findCareerWithKeyword(Member requestMember, String keyword, String sort) {
-        List<BaseCareer> careers = new ArrayList<>();
-        careers.addAll(activityRepository.findByMemberIdAndNameContaining(requestMember.getId(),keyword));
-        careers.addAll(eduCareerRepository.findByMemberIdAndNameContaining(requestMember.getId(),keyword));
-        careers.addAll(employmentRepository.findByMemberIdAndNameContaining(requestMember.getId(),keyword));
-        careers.addAll(circleRepository.findByMemberIdAndNameContaining(requestMember.getId(),keyword));
-        careers.addAll(projectRepository.findByMemberIdAndNameContaining(requestMember.getId(),keyword));
-        careers.addAll(competitionRepository.findByMemberIdAndNameContaining(requestMember.getId(),keyword));
-
-        if ("new".equalsIgnoreCase(sort)) {
-            careers.sort(Comparator.comparing(BaseCareer::getEnddate).reversed());
-        } else {
-            careers.sort(Comparator.comparing(BaseCareer::getEnddate));
-        }
-
-        return careers.stream().limit(2)
-                .map(career -> new FindCareerResponse(career, career.getClass().getSimpleName()))
-                .collect(Collectors.toList());
-
-    }
-
-    @Override
-    public List<TimelineResponse> findCareerForTimeline(Member requestMember) {
-        Long memberId = requestMember.getId();
-        List<BaseCareer> careers = new ArrayList<>();
-
-
-        careers.addAll(activityRepository.findByMemberId(memberId));
-        careers.addAll(eduCareerRepository.findByMemberId(memberId));
-        careers.addAll(employmentRepository.findByMemberId(memberId));
-        careers.addAll(circleRepository.findByMemberId(memberId));
-        careers.addAll(projectRepository.findByMemberId(memberId));
-        careers.addAll(competitionRepository.findByMemberId(memberId));
-
-
-        careers.sort(Comparator.comparing(BaseCareer::getEnddate).reversed());
-
-        return careers.stream()
-                .map(career -> new TimelineResponse(career, resolveCareerType(career)))
-                .collect(Collectors.toList());
-    }
-
-    private CareerType resolveCareerType(BaseCareer career) {
-        if (career instanceof Activity) {
-            return CareerType.ACTIVITY;
-        } else if (career instanceof Project) {
-            return CareerType.PROJECT;
-        } else if (career instanceof Employment) {
-            return CareerType.EMP;
-        } else if (career instanceof EduCareer) {
-            return CareerType.EDU;
-        } else if (career instanceof Circle) {
-            return CareerType.CIRCLE;
-        } else if (career instanceof Competition) {
-            return CareerType.COM;
-        } else {
-            return CareerType.ETC;
-        }
-    }
-
-
-    private List<FindDetailResponse> buildDetailResponse(List<BaseCareerDetail> detailList, String sort) {
-        Map<String, Map<Long, List<BaseCareerDetail>>> groupedDetails = new HashMap<>();
-        for (BaseCareerDetail detail : detailList) {
-            String careerType = getCareerType(detail);
-            Long careerId = getCareerId(detail);
-            groupedDetails
-                    .computeIfAbsent(careerType, k -> new HashMap<>())
-                    .computeIfAbsent(careerId, k -> new ArrayList<>())
-                    .add(detail);
-        }
-
-        List<FindDetailResponse> result = new ArrayList<>();
-
-        for(Map.Entry<String, Map<Long, List<BaseCareerDetail>>> entry : groupedDetails.entrySet()) {
-            String type = entry.getKey();
-            Map<Long, List<BaseCareerDetail>> careerMap = entry.getValue();
-
-            for(Map.Entry<Long,List<BaseCareerDetail>> careerEntry : careerMap.entrySet()){
-                Long careerId = careerEntry.getKey();
-                List<BaseCareerDetail> details = careerEntry.getValue();
-                List<BaseCareerDetailResponse> detailResponses = new ArrayList<>();
-                FindDetailInfo detailInfo = extractDetailInfo(details);
-
-                for (BaseCareerDetail detail: details) {
-                    detailResponses.add(new BaseCareerDetailResponse(detail));
-                }
-
-                result.add(new FindDetailResponse(careerId,type,detailInfo.title,detailInfo.alias,detailInfo.startDate,detailInfo.endDate,detailResponses));
-            }
-        }
-        if (sort.equals("new")) {
-            result.stream().sorted(Comparator.comparing(FindDetailResponse::getEndDate).reversed());
-        } else {
-            result.stream().sorted(Comparator.comparing(FindDetailResponse::getEndDate).reversed());
-        }
-        return result;
-
-    }
-    private String getCareerType(BaseCareerDetail detail) {
-        switch (detail.getCareerType()) {
-            case ACTIVITY: return CareerType.ACTIVITY.getDescription();
-            case PROJECT: return CareerType.PROJECT.getDescription();
-            case EMP: return CareerType.EMP.getDescription();
-            case EDU: return CareerType.EDU.getDescription();
-            case COM: return CareerType.COM.getDescription();
-            case CIRCLE: return CareerType.CIRCLE.getDescription();
-            default: return null;
-        }
-    }
-    private Long getCareerId(BaseCareerDetail detail) {
-        switch (detail.getCareerType()) {
-            case ACTIVITY: return detail.getActivity().getId();
-            case PROJECT: return detail.getProject().getId();
-            case EMP: return detail.getEmployment().getId();
-            case EDU: return detail.getEduCareer().getId();
-            case COM: return detail.getCompetition().getId();
-            case CIRCLE: return detail.getCircle().getId();
-            default: return null;
-        }
-    }
-    private FindDetailInfo extractDetailInfo(List<BaseCareerDetail> details) {
-        if (details.isEmpty()) {
-            return new FindDetailInfo(null, null, null, null);
-        }
-
-        BaseCareerDetail firstDetail = details.get(0);
-        String title = null;
-        String alias = null;
-        LocalDate startDate = null;
-        LocalDate endDate = null;
-
-        switch (firstDetail.getCareerType()) {
-            case ACTIVITY -> {
-                title = firstDetail.getActivity().getName();
-                alias = firstDetail.getActivity().getAlias();
-            }
-            case PROJECT -> {
-                title = firstDetail.getProject().getName();
-                alias = firstDetail.getProject().getAlias();
-            }
-            case EMP -> {
-                title = firstDetail.getEmployment().getName();
-                alias = firstDetail.getEmployment().getAlias();
-            }
-            case EDU -> {
-                title = firstDetail.getEduCareer().getName();
-                alias = firstDetail.getEduCareer().getAlias();
-            }
-            case COM -> {
-                title = firstDetail.getCompetition().getName();
-                alias = firstDetail.getCompetition().getAlias();
-            }
-            case CIRCLE -> {
-                title = firstDetail.getCircle().getName();
-                alias = firstDetail.getCircle().getAlias();
-            }
-        }
-
-        startDate = firstDetail.getStartDate();
-        endDate = firstDetail.getEndDate();
-
-        return new FindDetailInfo(title, alias, startDate, endDate);
-    }
 
     private <T extends BaseCareer, R extends BaseCareerResponse> R getResponse(T career,  BiFunction<T, List<BaseCareerDetail>, R> responseConstructor) {
         List<BaseCareerDetail> details;
@@ -772,18 +438,4 @@ public class BaseCareerServiceImpl implements BaseCareerService{
             activity.setYear(activity.getEnddate().getYear());
         }
     }
-    private static class FindDetailInfo {
-        String title;
-        String alias;
-        LocalDate startDate;
-        LocalDate endDate;
-
-        FindDetailInfo(String title, String alias, LocalDate startDate, LocalDate endDate) {
-            this.title = title;
-            this.alias = alias;
-            this.startDate = startDate;
-            this.endDate = endDate;
-        }
-    }
-
 }

--- a/src/main/java/umc/kkijuk/server/career/service/CareerServiceImpl.java
+++ b/src/main/java/umc/kkijuk/server/career/service/CareerServiceImpl.java
@@ -11,6 +11,7 @@ import umc.kkijuk.server.career.repository.*;
 import umc.kkijuk.server.common.domian.exception.OwnerMismatchException;
 import umc.kkijuk.server.common.domian.exception.ResourceNotFoundException;
 import umc.kkijuk.server.detail.domain.BaseCareerDetail;
+import umc.kkijuk.server.detail.domain.CareerType;
 import umc.kkijuk.server.detail.repository.BaseCareerDetailRepository;
 import umc.kkijuk.server.member.domain.Member;
 
@@ -406,25 +407,28 @@ public class CareerServiceImpl implements CareerService{
     private <T extends BaseCareer, R extends BaseCareerResponse> R getResponse(T career,  BiFunction<T, List<BaseCareerDetail>, R> responseConstructor) {
         List<BaseCareerDetail> details;
         if (career instanceof Activity) {
-            details = Optional.ofNullable(detailRepository.findByActivity((Activity) career))
+            details = Optional.ofNullable(detailRepository.findByCareerIdAndCareerType(CareerType.ACTIVITY, career.getId()))
                     .orElseGet(Collections::emptyList);
         } else if (career instanceof Circle) {
-            details = Optional.ofNullable(detailRepository.findByCircle((Circle) career))
+            details = Optional.ofNullable(detailRepository.findByCareerIdAndCareerType(CareerType.CIRCLE, career.getId()))
                     .orElseGet(Collections::emptyList);
         } else if (career instanceof Competition) {
-            details = Optional.ofNullable(detailRepository.findByCompetition((Competition) career))
+            details = Optional.ofNullable(detailRepository.findByCareerIdAndCareerType(CareerType.COM, career.getId()))
                     .orElseGet(Collections::emptyList);
         } else if (career instanceof EduCareer) {
-            details =Optional.ofNullable(detailRepository.findByEduCareer((EduCareer) career))
+            details =Optional.ofNullable(detailRepository.findByCareerIdAndCareerType(CareerType.EDU, career.getId()))
                     .orElseGet(Collections::emptyList);
         } else if (career instanceof Employment) {
-            details = Optional.ofNullable( detailRepository.findByEmployment((Employment) career))
+            details = Optional.ofNullable( detailRepository.findByCareerIdAndCareerType(CareerType.EMP, career.getId()))
                     .orElseGet(Collections::emptyList);
-
         } else if (career instanceof Project) {
-            details = Optional.ofNullable( detailRepository.findByProject((Project) career))
+            details = Optional.ofNullable( detailRepository.findByCareerIdAndCareerType(CareerType.PROJECT, career.getId()))
                     .orElseGet(Collections::emptyList);
-        } else {
+        } else if (career instanceof CareerEtc) {
+            details = Optional.ofNullable( detailRepository.findByCareerIdAndCareerType(CareerType.ETC, career.getId()))
+                    .orElseGet(Collections::emptyList);
+        }
+        else {
             throw new IllegalArgumentException("지원하지 않는 타입입니다.");
         }
         return responseConstructor.apply(career,details);

--- a/src/main/java/umc/kkijuk/server/dashboard/service/DashBoardServiceImpl.java
+++ b/src/main/java/umc/kkijuk/server/dashboard/service/DashBoardServiceImpl.java
@@ -32,6 +32,7 @@ public class DashBoardServiceImpl implements DashBoardService {
     private final EduCareerRepository eduCareerRepository;
     private final EmploymentRepository employmentRepository;
     private final ProjectRepository projectRepository;
+    private final CareerEtcRepository etcRepository;
 
     @Override
     public DashBoardUserInfoResponse getUserInfo(Member requestMember) {
@@ -62,7 +63,9 @@ public class DashBoardServiceImpl implements DashBoardService {
                         competitionRepository.findByMemberId(memberId),
                         eduCareerRepository.findByMemberId(memberId),
                         employmentRepository.findByMemberId(memberId),
-                        projectRepository.findByMemberId(memberId)
+                        projectRepository.findByMemberId(memberId),
+                        etcRepository.findByMemberId(memberId)
+
                 )
                 .mapToLong(List::size)
                 .sum();

--- a/src/main/java/umc/kkijuk/server/detail/domain/BaseCareerDetail.java
+++ b/src/main/java/umc/kkijuk/server/detail/domain/BaseCareerDetail.java
@@ -29,6 +29,9 @@ public class BaseCareerDetail extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private CareerType careerType;
 
+    @Column(nullable = false)
+    private Long careerId;
+
 
     @Column(nullable = false)
     private Long memberId;
@@ -38,33 +41,34 @@ public class BaseCareerDetail extends BaseEntity {
 
 
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="activity_id")
-    private Activity activity;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="circle_id")
-    private Circle circle;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="competition_id")
-    private Competition competition;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="edu_id")
-    private EduCareer eduCareer;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="employment_id")
-    private Employment employment;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="project_id")
-    private Project project;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="etc_id")
-    private CareerEtc etc;
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name="activity_id")
+//    private Activity activity;
+//
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name="circle_id")
+//    private Circle circle;
+//
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name="competition_id")
+//    private Competition competition;
+//
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name="edu_id")
+//    private EduCareer eduCareer;
+//
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name="employment_id")
+//    private Employment employment;
+//
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name="project_id")
+//    private Project project;
+//
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name="etc_id")
+//    private CareerEtc etc;
 
 
 

--- a/src/main/java/umc/kkijuk/server/detail/domain/BaseCareerDetail.java
+++ b/src/main/java/umc/kkijuk/server/detail/domain/BaseCareerDetail.java
@@ -62,6 +62,10 @@ public class BaseCareerDetail extends BaseEntity {
     @JoinColumn(name="project_id")
     private Project project;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="etc_id")
+    private CareerEtc etc;
+
 
 
 

--- a/src/main/java/umc/kkijuk/server/detail/domain/CareerType.java
+++ b/src/main/java/umc/kkijuk/server/detail/domain/CareerType.java
@@ -1,20 +1,24 @@
 package umc.kkijuk.server.detail.domain;
 
 public enum CareerType {
-    ACTIVITY("대외활동"),
-    PROJECT("프로젝트"),
-    EDU("교육"),
-    EMP("경력"),
-    CIRCLE("동아리"),
-    COM("대회");
+    ACTIVITY(1,"대외활동"),
+    PROJECT(2,"프로젝트"),
+    EDU(3,"교육"),
+    EMP(4,"경력"),
+    CIRCLE(5,"동아리"),
+    COM(6,"대회"),
+    ETC(7,"기타");
 
+    private final int id;
     private final String description;
 
-    CareerType(String description) {
+    CareerType(int id,String description) {
+        this.id = id;
         this.description = description;
     }
 
     public String getDescription() {
         return description;
     }
+    public int getId() {return id;}
 }

--- a/src/main/java/umc/kkijuk/server/detail/domain/CareerType.java
+++ b/src/main/java/umc/kkijuk/server/detail/domain/CareerType.java
@@ -1,24 +1,40 @@
 package umc.kkijuk.server.detail.domain;
 
+import umc.kkijuk.server.career.domain.*;
+
 public enum CareerType {
-    ACTIVITY(1,"대외활동"),
-    PROJECT(2,"프로젝트"),
-    EDU(3,"교육"),
-    EMP(4,"경력"),
-    CIRCLE(5,"동아리"),
-    COM(6,"대회"),
-    ETC(7,"기타");
+    ACTIVITY(1,"대외활동", Activity.class),
+    PROJECT(2,"프로젝트", Project.class),
+    EDU(3,"교육", EduCareer.class),
+    EMP(4,"경력", Employment.class),
+    CIRCLE(5,"동아리", Circle.class),
+    COM(6,"대회", Competition.class),
+    ETC(7,"기타", CareerEtc.class);
 
     private final int id;
     private final String description;
+    private final Class<? extends BaseCareer> career;
 
-    CareerType(int id,String description) {
+    CareerType(int id, String description, Class<? extends BaseCareer> career) {
         this.id = id;
         this.description = description;
+        this.career = career;
     }
 
     public String getDescription() {
         return description;
     }
     public int getId() {return id;}
+    public Class<? extends BaseCareer> getCareer() {
+        return career;
+    }
+    public static CareerType fromClass(BaseCareer careerClass){
+        for (CareerType type : values()) {
+            if (type.getCareer().equals(careerClass.getClass())) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("지원하는 활동이 아닙니다 : " + careerClass.getClass());
+
+    }
 }

--- a/src/main/java/umc/kkijuk/server/detail/dto/converter/BaseCareerDetailConverter.java
+++ b/src/main/java/umc/kkijuk/server/detail/dto/converter/BaseCareerDetailConverter.java
@@ -8,76 +8,86 @@ import umc.kkijuk.server.member.domain.Member;
 import java.util.ArrayList;
 
 public class BaseCareerDetailConverter {
-    public static BaseCareerDetail toBaseCareerDetail(Member requestMember, CareerDetailReqDto request, BaseCareer baseCareer) {
-        if(baseCareer instanceof Activity){
-            return BaseCareerDetail.builder()
-                    .activity((Activity) baseCareer)
-                    .careerType(request.getCareerType())
-                    .memberId(requestMember.getId())
-                    .title(request.getTitle())
-                    .content(request.getContent())
-                    .startDate(request.getStartDate())
-                    .endDate(request.getEndDate())
-                    .careerTagList(new ArrayList<>())
-                    .build();
-
-        }else if ( baseCareer instanceof Project){
-            return BaseCareerDetail.builder()
-                    .project((Project) baseCareer)
-                    .careerType(request.getCareerType())
-                    .memberId(requestMember.getId())
-                    .title(request.getTitle())
-                    .content(request.getContent())
-                    .startDate(request.getStartDate())
-                    .endDate(request.getEndDate())
-                    .careerTagList(new ArrayList<>())
-                    .build();
-        }else if ( baseCareer instanceof Circle){
-            return BaseCareerDetail.builder()
-                    .circle((Circle) baseCareer)
-                    .careerType(request.getCareerType())
-                    .memberId(requestMember.getId())
-                    .title(request.getTitle())
-                    .content(request.getContent())
-                    .startDate(request.getStartDate())
-                    .endDate(request.getEndDate())
-                    .careerTagList(new ArrayList<>())
-                    .build();
-        }else if ( baseCareer instanceof Employment){
-            return BaseCareerDetail.builder()
-                    .employment((Employment) baseCareer)
-                    .careerType(request.getCareerType())
-                    .memberId(requestMember.getId())
-                    .title(request.getTitle())
-                    .content(request.getContent())
-                    .startDate(request.getStartDate())
-                    .endDate(request.getEndDate())
-                    .careerTagList(new ArrayList<>())
-                    .build();
-        }else if ( baseCareer instanceof EduCareer){
-            return BaseCareerDetail.builder()
-                    .eduCareer((EduCareer) baseCareer)
-                    .careerType(request.getCareerType())
-                    .memberId(requestMember.getId())
-                    .title(request.getTitle())
-                    .content(request.getContent())
-                    .startDate(request.getStartDate())
-                    .endDate(request.getEndDate())
-                    .careerTagList(new ArrayList<>())
-                    .build();
-        }else{
-            return BaseCareerDetail.builder()
-                    .competition((Competition) baseCareer)
-                    .careerType(request.getCareerType())
-                    .memberId(requestMember.getId())
-                    .title(request.getTitle())
-                    .content(request.getContent())
-                    .startDate(request.getStartDate())
-                    .endDate(request.getEndDate())
-                    .careerTagList(new ArrayList<>())
-                    .build();
-
-        }
+    public static BaseCareerDetail toBaseCareerDetail(Member requestMember, CareerDetailReqDto request, Long careerId) {
+        return BaseCareerDetail.builder()
+                .careerType(request.getCareerType())
+                .memberId(requestMember.getId())
+                .careerId(careerId)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .careerTagList(new ArrayList<>())
+                .build();
+//        if(baseCareer instanceof Activity){
+//            return BaseCareerDetail.builder()
+//                    .activity((Activity) baseCareer)
+//                    .careerType(request.getCareerType())
+//                    .memberId(requestMember.getId())
+//                    .title(request.getTitle())
+//                    .content(request.getContent())
+//                    .startDate(request.getStartDate())
+//                    .endDate(request.getEndDate())
+//                    .careerTagList(new ArrayList<>())
+//                    .build();
+//
+//        }else if ( baseCareer instanceof Project){
+//            return BaseCareerDetail.builder()
+//                    .project((Project) baseCareer)
+//                    .careerType(request.getCareerType())
+//                    .memberId(requestMember.getId())
+//                    .title(request.getTitle())
+//                    .content(request.getContent())
+//                    .startDate(request.getStartDate())
+//                    .endDate(request.getEndDate())
+//                    .careerTagList(new ArrayList<>())
+//                    .build();
+//        }else if ( baseCareer instanceof Circle){
+//            return BaseCareerDetail.builder()
+//                    .circle((Circle) baseCareer)
+//                    .careerType(request.getCareerType())
+//                    .memberId(requestMember.getId())
+//                    .title(request.getTitle())
+//                    .content(request.getContent())
+//                    .startDate(request.getStartDate())
+//                    .endDate(request.getEndDate())
+//                    .careerTagList(new ArrayList<>())
+//                    .build();
+//        }else if ( baseCareer instanceof Employment){
+//            return BaseCareerDetail.builder()
+//                    .employment((Employment) baseCareer)
+//                    .careerType(request.getCareerType())
+//                    .memberId(requestMember.getId())
+//                    .title(request.getTitle())
+//                    .content(request.getContent())
+//                    .startDate(request.getStartDate())
+//                    .endDate(request.getEndDate())
+//                    .careerTagList(new ArrayList<>())
+//                    .build();
+//        }else if ( baseCareer instanceof EduCareer){
+//            return BaseCareerDetail.builder()
+//                    .eduCareer((EduCareer) baseCareer)
+//                    .careerType(request.getCareerType())
+//                    .memberId(requestMember.getId())
+//                    .title(request.getTitle())
+//                    .content(request.getContent())
+//                    .startDate(request.getStartDate())
+//                    .endDate(request.getEndDate())
+//                    .careerTagList(new ArrayList<>())
+//                    .build();
+//        }else{
+//            return BaseCareerDetail.builder()
+//                    .competition((Competition) baseCareer)
+//                    .careerType(request.getCareerType())
+//                    .memberId(requestMember.getId())
+//                    .title(request.getTitle())
+//                    .content(request.getContent())
+//                    .startDate(request.getStartDate())
+//                    .endDate(request.getEndDate())
+//                    .careerTagList(new ArrayList<>())
+//                    .build();
+//
+//        }
 
     }
 

--- a/src/main/java/umc/kkijuk/server/detail/repository/BaseCareerDetailRepository.java
+++ b/src/main/java/umc/kkijuk/server/detail/repository/BaseCareerDetailRepository.java
@@ -39,6 +39,13 @@ public interface BaseCareerDetailRepository extends JpaRepository<BaseCareerDeta
             "LEFT JOIN FETCH ct.tag t " +
             "WHERE bcd.employment = :emp")
     List<BaseCareerDetail> findByEmployment(Employment emp);
+
+    @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
+            "LEFT JOIN FETCH bcd.careerTagList ct " +
+            "LEFT JOIN FETCH ct.tag t " +
+            "WHERE bcd.etc = :etc")
+    List<BaseCareerDetail> findByEtc(CareerEtc etc);
+
     @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
             "LEFT JOIN FETCH bcd.careerTagList ct " +
             "LEFT JOIN FETCH ct.tag t " +
@@ -51,6 +58,7 @@ public interface BaseCareerDetailRepository extends JpaRepository<BaseCareerDeta
             "JOIN FETCH ct.tag t " +
             "WHERE EXISTS (SELECT 1 FROM CareerDetailTag ct2 WHERE ct2.baseCareerDetail=bcd AND ct2.tag.id=:tagId)" )
     List<BaseCareerDetail> findByTag(@Param("tagId") Long tagId);
+
 
 
 }

--- a/src/main/java/umc/kkijuk/server/detail/repository/BaseCareerDetailRepository.java
+++ b/src/main/java/umc/kkijuk/server/detail/repository/BaseCareerDetailRepository.java
@@ -5,47 +5,55 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.kkijuk.server.career.domain.*;
 import umc.kkijuk.server.detail.domain.BaseCareerDetail;
+import umc.kkijuk.server.detail.domain.CareerType;
 
 import java.util.List;
 
 public interface BaseCareerDetailRepository extends JpaRepository<BaseCareerDetail,Long> {
-    @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
-            "LEFT JOIN FETCH bcd.careerTagList ct " +
-            "LEFT JOIN FETCH  ct.tag t " +
-            "WHERE bcd.competition = :competition")
-    List<BaseCareerDetail> findByCompetition(Competition competition);
-    @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
-            "LEFT JOIN FETCH bcd.careerTagList ct " +
-            "LEFT JOIN FETCH ct.tag t " +
-            "WHERE bcd.activity = :activity")
-    List<BaseCareerDetail> findByActivity(Activity activity);
-    @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
-            "LEFT JOIN FETCH bcd.careerTagList ct " +
-            "LEFT JOIN FETCH ct.tag t " +
-            "WHERE bcd.circle = :circle")
-    List<BaseCareerDetail> findByCircle(Circle circle);
-    @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
-            "LEFT JOIN FETCH bcd.careerTagList ct " +
-            "LEFT JOIN FETCH ct.tag t " +
-            "WHERE bcd.project = :project")
-    List<BaseCareerDetail> findByProject(Project project);
-    @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
-            "LEFT JOIN FETCH bcd.careerTagList ct " +
-            "LEFT JOIN FETCH ct.tag t " +
-            "WHERE bcd.eduCareer = :edu")
-    List<BaseCareerDetail> findByEduCareer(EduCareer edu);
-    @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
-            "LEFT JOIN FETCH bcd.careerTagList ct " +
-            "LEFT JOIN FETCH ct.tag t " +
-            "WHERE bcd.employment = :emp")
-    List<BaseCareerDetail> findByEmployment(Employment emp);
+//    @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
+//            "LEFT JOIN FETCH bcd.careerTagList ct " +
+//            "LEFT JOIN FETCH  ct.tag t " +
+//            "WHERE bcd.competition = :competition")
+//    List<BaseCareerDetail> findByCompetition(Competition competition);
+//    @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
+//            "LEFT JOIN FETCH bcd.careerTagList ct " +
+//            "LEFT JOIN FETCH ct.tag t " +
+//            "WHERE bcd.activity = :activity")
+//    List<BaseCareerDetail> findByActivity(Activity activity);
+//    @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
+//            "LEFT JOIN FETCH bcd.careerTagList ct " +
+//            "LEFT JOIN FETCH ct.tag t " +
+//            "WHERE bcd.circle = :circle")
+//    List<BaseCareerDetail> findByCircle(Circle circle);
+//    @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
+//            "LEFT JOIN FETCH bcd.careerTagList ct " +
+//            "LEFT JOIN FETCH ct.tag t " +
+//            "WHERE bcd.project = :project")
+//    List<BaseCareerDetail> findByProject(Project project);
+//    @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
+//            "LEFT JOIN FETCH bcd.careerTagList ct " +
+//            "LEFT JOIN FETCH ct.tag t " +
+//            "WHERE bcd.eduCareer = :edu")
+//    List<BaseCareerDetail> findByEduCareer(EduCareer edu);
+//    @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
+//            "LEFT JOIN FETCH bcd.careerTagList ct " +
+//            "LEFT JOIN FETCH ct.tag t " +
+//            "WHERE bcd.employment = :emp")
+//    List<BaseCareerDetail> findByEmployment(Employment emp);
+//
+//    @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
+//            "LEFT JOIN FETCH bcd.careerTagList ct " +
+//            "LEFT JOIN FETCH ct.tag t " +
+//            "WHERE bcd.etc = :etc")
+//    List<BaseCareerDetail> findByEtc(CareerEtc etc);
 
-    @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
+    @Query("SELECT DISTINCT bcd FROM BaseCareerDetail  bcd " +
             "LEFT JOIN FETCH bcd.careerTagList ct " +
-            "LEFT JOIN FETCH ct.tag t " +
-            "WHERE bcd.etc = :etc")
-    List<BaseCareerDetail> findByEtc(CareerEtc etc);
-
+            "LEFT JOIN FETCH ct.tag t "+
+            "WHERE bcd.careerType = :careerType AND bcd.careerId = :careerId"
+    )
+    List<BaseCareerDetail> findByCareerIdAndCareerType(@Param("careerType") CareerType careerType,
+                                                       @Param("careerId") Long careerId);
     @Query("SELECT DISTINCT bcd FROM BaseCareerDetail bcd " +
             "LEFT JOIN FETCH bcd.careerTagList ct " +
             "LEFT JOIN FETCH ct.tag t " +
@@ -58,7 +66,4 @@ public interface BaseCareerDetailRepository extends JpaRepository<BaseCareerDeta
             "JOIN FETCH ct.tag t " +
             "WHERE EXISTS (SELECT 1 FROM CareerDetailTag ct2 WHERE ct2.baseCareerDetail=bcd AND ct2.tag.id=:tagId)" )
     List<BaseCareerDetail> findByTag(@Param("tagId") Long tagId);
-
-
-
 }

--- a/src/main/java/umc/kkijuk/server/detail/service/BaseCareerDetailServiceImpl.java
+++ b/src/main/java/umc/kkijuk/server/detail/service/BaseCareerDetailServiceImpl.java
@@ -43,11 +43,10 @@ public class BaseCareerDetailServiceImpl implements BaseCareerDetailService{
         validateOwner(career, requestMember);
 
         List<CareerDetailTag> detailTagList = returnCareerTagList(request.getTagList());
-        BaseCareerDetail newBaseCareerDetail = BaseCareerDetailConverter.toBaseCareerDetail(requestMember, request, career);
+        BaseCareerDetail newBaseCareerDetail = BaseCareerDetailConverter.toBaseCareerDetail(requestMember, request, careerId);
 
-        addDetailToCareer(career, newBaseCareerDetail);
+//        addDetailToCareer(career, newBaseCareerDetail);
         detailTagList.forEach(tag -> tag.setBaseCareerDetail(newBaseCareerDetail));
-
         return new BaseCareerDetailResponse(baseCareerDetailRepository.save(newBaseCareerDetail));
     }
 
@@ -95,24 +94,23 @@ public class BaseCareerDetailServiceImpl implements BaseCareerDetailService{
         }
     }
 
-    private void addDetailToCareer(BaseCareer career, BaseCareerDetail detail) {
-        if (career instanceof Competition) {
-            ((Competition) career).getDetailList().add(detail);
-        } else if (career instanceof Activity) {
-            ((Activity) career).getDetailList().add(detail);
-        } else if (career instanceof EduCareer) {
-            ((EduCareer) career).getDetailList().add(detail);
-        } else if (career instanceof Employment) {
-            ((Employment) career).getDetailList().add(detail);
-        } else if (career instanceof Circle) {
-            ((Circle) career).getDetailList().add(detail);
-        } else if (career instanceof Project) {
-            ((Project) career).getDetailList().add(detail);
-        } else {
-            throw new IllegalArgumentException("지원하지 않는 활동 유형입니다.");
-        }
-    }
-
+//    private void addDetailToCareer(BaseCareer career, BaseCareerDetail detail) {
+//        if (career instanceof Competition) {
+//            ((Competition) career).getDetailList().add(detail);
+//        } else if (career instanceof Activity) {
+//            ((Activity) career).getDetailList().add(detail);
+//        } else if (career instanceof EduCareer) {
+//            ((EduCareer) career).getDetailList().add(detail);
+//        } else if (career instanceof Employment) {
+//            ((Employment) career).getDetailList().add(detail);
+//        } else if (career instanceof Circle) {
+//            ((Circle) career).getDetailList().add(detail);
+//        } else if (career instanceof Project) {
+//            ((Project) career).getDetailList().add(detail);
+//        } else {
+//            throw new IllegalArgumentException("지원하지 않는 활동 유형입니다.");
+//        }
+//    }
     private BaseCareer findBaseCareerByType(CareerType careerType, Long careerId) {
         return switch (careerType) {
             case ACTIVITY -> activityRepository.findById(careerId)

--- a/src/main/java/umc/kkijuk/server/record/service/RecordServiceImpl.java
+++ b/src/main/java/umc/kkijuk/server/record/service/RecordServiceImpl.java
@@ -10,6 +10,7 @@ import umc.kkijuk.server.common.domian.exception.IntroFoundException;
 import umc.kkijuk.server.common.domian.exception.IntroOwnerMismatchException;
 import umc.kkijuk.server.common.domian.exception.RecordNotFoundException;
 import umc.kkijuk.server.common.domian.exception.ResourceNotFoundException;
+import umc.kkijuk.server.detail.domain.CareerType;
 import umc.kkijuk.server.member.domain.Member;
 import umc.kkijuk.server.member.repository.MemberRepository;
 import umc.kkijuk.server.record.controller.response.*;
@@ -40,6 +41,8 @@ public class RecordServiceImpl implements RecordService {
     private final EduCareerRepository eduCareerRepository;
     private final EmploymentRepository employmentRepository;
     private final ProjectRepository projectRepository;
+    private final CareerEtcRepository etcRepository;
+
     private final FileRepository fileRepository;
 
     @Override
@@ -85,12 +88,16 @@ public class RecordServiceImpl implements RecordService {
                 .sorted(Comparator.comparing(EmploymentResponse::getEndDate).reversed())
                 .toList();
 
-        // 활동 및 경험 ( 동아리, 대외활동)
+        // 활동 및 경험 ( 동아리, 대외활동, 기타 )
         List<BaseCareerResponse> activitiesAndExperiences = activityRepository.findByMemberId(memberId).stream()
                 .map(ActivityResponse::new)
                 .collect(Collectors.toList());
+
         activitiesAndExperiences.addAll(circleRepository.findByMemberId(memberId).stream()
                 .map(CircleResponse::new).collect(Collectors.toList()));
+        activitiesAndExperiences.addAll(etcRepository.findByMemberId(memberId).stream()
+                .map(EtcResponse::new).collect(Collectors.toList()));
+
         activitiesAndExperiences.stream().sorted(Comparator.comparing(BaseCareerResponse::getEndDate).reversed());
 
         // 프로젝트 ( 프로젝트, 공모전/대회)
@@ -158,12 +165,15 @@ public class RecordServiceImpl implements RecordService {
                 .sorted(Comparator.comparing(EmploymentResponse::getEndDate).reversed())
                 .toList();
 
-        //활동 및 경험 ( 동아리, 대외활동)
+        //활동 및 경험 ( 동아리, 대외활동, 기타 )
         List<BaseCareerResponse> activitiesAndExperiences = activityRepository.findByMemberId(memberId).stream()
                 .map(ActivityResponse::new)
                 .collect(Collectors.toList());
         activitiesAndExperiences.addAll(circleRepository.findByMemberId(memberId).stream()
                 .map(CircleResponse::new).collect(Collectors.toList()));
+        activitiesAndExperiences.addAll(etcRepository.findByMemberId(memberId).stream()
+                .map(EtcResponse::new).collect(Collectors.toList()));
+
         activitiesAndExperiences.stream().sorted(Comparator.comparing(BaseCareerResponse::getEndDate).reversed());
 
         //프로젝트 ( 프로젝트, 공모전/대회)
@@ -224,33 +234,39 @@ public class RecordServiceImpl implements RecordService {
         Record record = recordRepository.findByMemberId(memberId);
 
         List<ResumeResponse> employments = employmentRepository.findByMemberId(memberId).stream()
-                .map(employment -> new ResumeResponse(employment.getId(),"경력",employment.getName(),
+                .map(employment -> new ResumeResponse(employment.getId(),CareerType.EMP.getDescription(),employment.getName(),
                         employment.getAlias(),employment.getSummary(),employment.getStartdate(),
                         employment.getEnddate())).collect(Collectors.toList());
+        //활동 및 경험 ( 대외 활동, 동아리, 기타 )
 
         List<ResumeResponse> activitiesAndExperiences = activityRepository.findByMemberId(memberId).stream()
-                .map(activity -> new ResumeResponse(activity.getId(), "대외활동",activity.getName(),
+                .map(activity -> new ResumeResponse(activity.getId(), CareerType.ACTIVITY.getDescription(), activity.getName(),
                         activity.getAlias(),activity.getSummary(),activity.getStartdate(),
                         activity.getEnddate())).collect(Collectors.toList());
 
         activitiesAndExperiences.addAll(circleRepository.findByMemberId(memberId).stream()
-                .map(circle->new ResumeResponse(circle.getId(),"동아리",circle.getName(),
+                .map(circle->new ResumeResponse(circle.getId(),CareerType.CIRCLE.getDescription(), circle.getName(),
                         circle.getAlias(),circle.getSummary(),circle.getStartdate(),
                         circle.getEnddate())).collect(Collectors.toList()));
 
+        activitiesAndExperiences.addAll(etcRepository.findByMemberId(memberId).stream()
+                .map(etc -> new ResumeResponse(etc.getId(), CareerType.ETC.getDescription(), etc.getName(),
+                        etc.getAlias(), etc.getSummary(), etc.getStartdate(),
+                        etc.getEnddate())).collect(Collectors.toList()));
+
         //프로젝트 ( 프로젝트, 공모전/대회)
         List<ResumeResponse> projectsAndComp = projectRepository.findByMemberId(memberId).stream()
-                .map(project->new ResumeResponse(project.getId(),"프로젝트",project.getName(),
+                .map(project->new ResumeResponse(project.getId(),CareerType.PROJECT.getDescription(), project.getName(),
                         project.getAlias(),project.getSummary(),project.getStartdate(),
                         project.getEnddate())).collect(Collectors.toList());
 
         projectsAndComp.addAll(competitionRepository.findByMemberId(memberId).stream()
-                .map(comp -> new ResumeResponse(comp.getId(),"공모전/대회", comp.getName(),
+                .map(comp -> new ResumeResponse(comp.getId(),CareerType.COM.getDescription(), comp.getName(),
                         comp.getAlias(),comp.getSummary(),comp.getStartdate(),
                         comp.getEnddate())).collect(Collectors.toList()));
 
         List<ResumeResponse> eduCareers = eduCareerRepository.findByMemberId(memberId).stream()
-                .map(edu-> new ResumeResponse(edu.getId(),"교육",edu.getName(),
+                .map(edu-> new ResumeResponse(edu.getId(),CareerType.EDU.getDescription(),edu.getName(),
                         edu.getAlias(),edu.getSummary(),edu.getStartdate(),
                         edu.getEnddate())).collect(Collectors.toList());
 

--- a/src/test/java/umc/kkijuk/server/unitTest/career/controller/CareerControllerTest.java
+++ b/src/test/java/umc/kkijuk/server/unitTest/career/controller/CareerControllerTest.java
@@ -11,7 +11,7 @@ import umc.kkijuk.server.career.controller.BaseCareerController;
 import umc.kkijuk.server.career.controller.response.*;
 import umc.kkijuk.server.career.domain.*;
 import umc.kkijuk.server.career.dto.*;
-import umc.kkijuk.server.career.service.BaseCareerServiceImpl;
+import umc.kkijuk.server.career.service.CareerServiceImpl;
 import umc.kkijuk.server.common.domian.exception.ResourceNotFoundException;
 import umc.kkijuk.server.detail.domain.CareerType;
 import umc.kkijuk.server.login.controller.dto.LoginInfo;
@@ -28,7 +28,7 @@ public class CareerControllerTest {
     @InjectMocks
     private BaseCareerController careerController;
     @Mock
-    private BaseCareerServiceImpl baseCareerService;
+    private CareerServiceImpl baseCareerService;
     @Mock
     private MemberServiceImpl memberService;
     public final Long requestMemberId = 1L;


### PR DESCRIPTION
- CareerEtc 엔티티를 추가하고 생성, 수정, 삭제 API를 추가하였습니다.
- Dashboard API와 이력서 조회 기능에 CareerEtc 데이터 조회 로직을 추가했습니다.
- Career와 CareerDetail 엔티티 간의 연관관계를 수정하고 관련 서비스 로직을 업데이트했습니다.
- CareerSearchService를 추가하여 Career 조회 기능을 분리하였습니다.
- 활동 검색 기능과 타임라인 API 의 category 응답 방식을 개선하였습니다.