### PR TITLE
♻️ Refactor : 내커리어 검색 부분 정렬, response에 Schema 추가, 공고 태그 초기화

### DIFF
--- a/src/main/java/umc/kkijuk/server/career/controller/response/ActivityResponse.java
+++ b/src/main/java/umc/kkijuk/server/career/controller/response/ActivityResponse.java
@@ -1,6 +1,7 @@
 package umc.kkijuk.server.career.controller.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import umc.kkijuk.server.career.domain.Activity;
 import umc.kkijuk.server.detail.controller.response.BaseCareerDetailResponse;
@@ -16,24 +17,39 @@ import java.util.stream.Collectors;
 @Setter
 @Builder
 @AllArgsConstructor
+@Schema(title="ActivityResponse : 내 커리어(대외활동) 생성 후 응답 DTO")
 public class ActivityResponse implements BaseCareerResponse{
+    @Schema(description = "대외활동 Id", example = "1")
     private Long id;
+    @Schema(description = "대외활동 카테고리 정보", example = "{ \"categoryId\": 1, \"categoryKoName\": \"대외활동\", \"categoryEnName\": \"ACTIVITY\" }")
     private CategoryResponse category;
+    @Schema(description = "대외활동 활동명", example = "00은행 홍보대사")
     private String name;
+    @Schema(description = "대외활동 별칭", example = "00손해보험 대학생 서포터즈")
     private String alias;
+    @Schema(description = "대외활동 기간 인지 여부", example = "false")
     private Boolean unknown;
+    @Schema(description = "대외활동 활동 내역")
     private String summary;
+
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate startdate;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate enddate;
 
+    @Schema(description = "대외활동 주최", example = "00여행사")
     private String organizer;
+
+    @Schema(description = "대외활동 역할", example = "팀장")
     private String role;
+    @Schema(description = "대외활동 팀 규모", example = "2")
     private int teamSize;
+    @Schema(description = "대외활동 기여도", example = "100")
     private int contribution;
+    @Schema(description = "대외활동 팀 여부", example = "true")
     private Boolean isTeam;
+    @Schema(description = "대외활동 활동 기록")
     private List<BaseCareerDetailResponse> detailList;
 
     public ActivityResponse(Activity activity) {

--- a/src/main/java/umc/kkijuk/server/career/controller/response/CategoryResponse.java
+++ b/src/main/java/umc/kkijuk/server/career/controller/response/CategoryResponse.java
@@ -1,5 +1,6 @@
 package umc.kkijuk.server.career.controller.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Data
@@ -7,6 +8,7 @@ import lombok.*;
 @Setter
 @Builder
 @AllArgsConstructor
+@Schema(title="CategoryResponse : 내 커리어 카테고리 DTO")
 public class CategoryResponse {
     private int categoryId;
     private String categoryKoName;

--- a/src/main/java/umc/kkijuk/server/career/controller/response/CircleResponse.java
+++ b/src/main/java/umc/kkijuk/server/career/controller/response/CircleResponse.java
@@ -1,5 +1,7 @@
 package umc.kkijuk.server.career.controller.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import umc.kkijuk.server.career.domain.Circle;
 import umc.kkijuk.server.detail.controller.response.BaseCareerDetailResponse;
@@ -15,17 +17,32 @@ import java.util.stream.Collectors;
 @Setter
 @Builder
 @AllArgsConstructor
+@Schema(title="CircleResponse : 내 커리어(동아리) 생성 후 응답 DTO")
 public class CircleResponse implements BaseCareerResponse{
+    @Schema(description = "동아리 Id", example = "1")
     private Long id;
+    @Schema(description = "동아리 카테고리 정보", example = "{ \"categoryId\": 5, \"categoryKoName\": \"동아리\", \"categoryEnName\": \"CIRCLE\" }")
     private CategoryResponse category;
+    @Schema(description = "동아리 활동명", example = "광고 기획 연합동아리")
     private String name;
+    @Schema(description = "동아리 별칭", example = "UMC")
     private String alias;
+    @Schema(description = "동아리 기간 인지 여부", example = "false")
     private Boolean unknown;
+    @Schema(description = "동아리 활동 내역")
     private String summary;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate startdate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate enddate;
+
+    @Schema(description = "동아리 소속", example = "true")
     private Boolean location;
+    @Schema(description = "동아리 역할", example = "동아리장")
     private String role;
+
+    @Schema(description = "동아리 활동 기록")
     private List<BaseCareerDetailResponse> detailList;
     public CircleResponse(Circle circle) {
         this.id = circle.getId();

--- a/src/main/java/umc/kkijuk/server/career/controller/response/CompetitionResponse.java
+++ b/src/main/java/umc/kkijuk/server/career/controller/response/CompetitionResponse.java
@@ -1,5 +1,7 @@
 package umc.kkijuk.server.career.controller.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import umc.kkijuk.server.career.domain.Competition;
 import umc.kkijuk.server.detail.controller.response.BaseCareerDetailResponse;
@@ -15,19 +17,36 @@ import java.util.stream.Collectors;
 @Setter
 @Builder
 @AllArgsConstructor
+@Schema(title="CompetitionResponse : 내 커리어(공모전대회) 생성 후 응답 DTO")
 public class CompetitionResponse implements BaseCareerResponse {
+    @Schema(description = "공모전대회 Id", example = "1")
     private Long id;
+    @Schema(description = "공모전대회 카테고리 정보", example = "{ \"categoryId\": 6, \"categoryKoName\": \"공모전대회\", \"categoryEnName\": \"COM\" }")
     private CategoryResponse category;
+    @Schema(description = "공모전대회 활동명", example = "PR 아이디어 공모전")
     private String name;
+    @Schema(description = "공모전대회 별칭", example = "2025 로레0 브랜드스톰 공모전")
     private String alias;
+    @Schema(description = "공모전대회 기간 인지 여부", example = "true")
     private Boolean unknown;
+    @Schema(description = "공모전대회 활동 내역")
     private String summary;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate startdate;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate enddate;
+
+    @Schema(description = "공모전대회 주최", example = "00문화재단")
     private String organizer;
+    @Schema(description = "공모전대회 팀 규모", example = "2")
     private int teamSize;
+    @Schema(description = "공모전대회 기여도", example = "100")
     private int contribution;
+    @Schema(description = "공모전대회 팀 여부", example = "true")
     private Boolean isTeam;
+    @Schema(description = "공모전대회 활동 기록")
     private List<BaseCareerDetailResponse> detailList;
     public CompetitionResponse(Competition competition) {
         this.id = competition.getId();

--- a/src/main/java/umc/kkijuk/server/career/controller/response/EduCareerResponse.java
+++ b/src/main/java/umc/kkijuk/server/career/controller/response/EduCareerResponse.java
@@ -1,5 +1,7 @@
 package umc.kkijuk.server.career.controller.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import umc.kkijuk.server.career.domain.BaseCareer;
 import umc.kkijuk.server.career.domain.EduCareer;
@@ -16,17 +18,34 @@ import java.util.stream.Collectors;
 @Setter
 @Builder
 @AllArgsConstructor
+@Schema(title="EduCareerResponse : 내 커리어(교육) 생성 후 응답 DTO")
 public class EduCareerResponse implements BaseCareerResponse {
+    @Schema(description = "교육 Id", example = "1")
     private Long id;
+    @Schema(description = "교육 카테고리 정보", example = "{ \"categoryId\": 3, \"categoryKoName\": \"교육\", \"categoryEnName\": \"EDU\" }")
     private CategoryResponse category;
+    @Schema(description = "교육 활동명", example = "데이터 분석 세미나")
     private String name;
+    @Schema(description = "교육 별칭", example = "000톤 정글 8기")
     private String alias;
+    @Schema(description = "교육 기간 인지 여부", example = "false")
     private Boolean unknown;
+    @Schema(description = "교육 활동 내역")
     private String summary;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate startdate;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate enddate;
+
+    @Schema(description = "교육 주최", example = "대한상공회의소")
     private String organizer;
+
+    @Schema(description = "교육 시간", example = "130")
     private int time;
+
+    @Schema(description = "교육 활동 기록")
     private List<BaseCareerDetailResponse> detailList;
     public EduCareerResponse(EduCareer eduCareer) {
         this.id = eduCareer.getId();

--- a/src/main/java/umc/kkijuk/server/career/controller/response/EmploymentResponse.java
+++ b/src/main/java/umc/kkijuk/server/career/controller/response/EmploymentResponse.java
@@ -1,5 +1,7 @@
 package umc.kkijuk.server.career.controller.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import umc.kkijuk.server.career.domain.Employment;
 import umc.kkijuk.server.career.domain.JobType;
@@ -17,17 +19,33 @@ import java.util.stream.Collectors;
 @Builder
 @AllArgsConstructor
 public class EmploymentResponse implements BaseCareerResponse{
+    @Schema(description = "경력 Id", example = "1")
     private Long id;
+    @Schema(description = "경력 카테고리 정보", example = "{ \"categoryId\": 3, \"categoryKoName\": \"교육\", \"categoryEnName\": \"EDU\" }")
     private CategoryResponse category;
+    @Schema(description = "경력 활동명", example = "학원 채점 아르바이트")
     private String name;
+    @Schema(description = "경력 근무처", example = "근무처")
     private String alias;
+    @Schema(description = "경력 기간 인지 여부", example = "false")
     private Boolean unknown;
+    @Schema(description = "경력 활동 내역")
     private String summary;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate startdate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate enddate;
+
+
+    @Schema(description = "직무 유형(분류)", example = "FULL_TIME", type = "string", allowableValues = {"FULL_TIME", "PART_TIME", "INTERNSHIP", "FREELANCE"})
     private JobType type;
+    @Schema(description = "경력 직급/직위", example = "인턴,보조강사")
+
     private String position;
+    @Schema(description = "경력 직무/분야", example = "서비스업,iOS 개발 등")
     private String field;
+    @Schema(description = "경력 활동 기록")
     private List<BaseCareerDetailResponse> detailList;
     @Override
     public LocalDate getEndDate() {

--- a/src/main/java/umc/kkijuk/server/career/controller/response/EtcResponse.java
+++ b/src/main/java/umc/kkijuk/server/career/controller/response/EtcResponse.java
@@ -1,5 +1,7 @@
 package umc.kkijuk.server.career.controller.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import umc.kkijuk.server.career.domain.CareerEtc;
 import umc.kkijuk.server.detail.controller.response.BaseCareerDetailResponse;
@@ -15,15 +17,27 @@ import java.util.stream.Collectors;
 @Setter
 @Builder
 @AllArgsConstructor
+@Schema(title="EtcResponse : 내 커리어(기타) 생성 후 응답 DTO")
 public class EtcResponse implements BaseCareerResponse{
+    @Schema(description = "기타 Id", example = "1")
     private Long id;
+    @Schema(description = "기타 카테고리 정보", example = "{ \"categoryId\": 7, \"categoryKoName\": \"기타\", \"categoryEnName\": \"ETC\" }")
     private CategoryResponse category;
+    @Schema(description = "기타 활동명", example = "필리핀 해외봉사")
     private String name;
+    @Schema(description = "기타 별칭", example = "000톤 정글 8")
     private String alias;
+    @Schema(description = "기타 기간 인지 여부", example = "false")
     private Boolean unknown;
+    @Schema(description = "기타 활동 내역")
     private String summary;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate startdate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate enddate;
+
+    @Schema(description = "대외활동 활동 기록")
     private List<BaseCareerDetailResponse> detailList;
 
     public EtcResponse(CareerEtc etc) {

--- a/src/main/java/umc/kkijuk/server/career/controller/response/ProjectResponse.java
+++ b/src/main/java/umc/kkijuk/server/career/controller/response/ProjectResponse.java
@@ -1,5 +1,7 @@
 package umc.kkijuk.server.career.controller.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import umc.kkijuk.server.career.domain.Project;
 import umc.kkijuk.server.career.domain.ProjectType;
@@ -16,20 +18,39 @@ import java.util.stream.Collectors;
 @Setter
 @Builder
 @AllArgsConstructor
+@Schema(title="ProjectResponse : 내 커리어(프로젝트) 생성 후 응답 DTO")
 public class ProjectResponse implements BaseCareerResponse {
+    @Schema(description = "프로젝트 Id", example = "1")
     private Long id;
+    @Schema(description = "프로젝트 카테고리 정보", example = "{ \"categoryId\": 2, \"categoryKoName\": \"프로젝트\", \"categoryEnName\": \"PROJECT\" }")
     private CategoryResponse category;
+    @Schema(description = "프로젝트 활동명", example = "광고 기획 동아리")
     private String name;
+    @Schema(description = "프로젝트 별칭", example = "UMC")
     private String alias;
+    @Schema(description = "프로젝트 기간 인지 여부", example = "false")
     private Boolean unknown;
+    @Schema(description = "프로젝트 활동 내역")
     private String summary;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate startdate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate enddate;
+
+    @Schema(description = "프로젝트 팀 규모", example = "2")
     private int teamSize;
+    @Schema(description = "프로젝트 팀 여부", example = "true")
     private Boolean isTeam;
+    @Schema(description = "프로젝트 기여도", example = "100")
     private int contribution;
+
+    @Schema(description = "프로젝트 소속", example = "OTHER", type = "string", allowableValues = {"ON_CAMPUS", "OFF_CAMPUS", "OTHER"})
     private ProjectType location;
+
+    @Schema(description = "프로젝트 활동 기록")
     private List<BaseCareerDetailResponse> detailList;
+
     public ProjectResponse(Project project) {
         this.id = project.getId();
         this.category = new CategoryResponse(CareerType.PROJECT.getId(),CareerType.PROJECT.getDescription(),CareerType.PROJECT.name());

--- a/src/main/java/umc/kkijuk/server/career/dto/ActivityReqDto.java
+++ b/src/main/java/umc/kkijuk/server/career/dto/ActivityReqDto.java
@@ -2,6 +2,8 @@ package umc.kkijuk.server.career.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -19,7 +21,7 @@ import java.time.LocalDate;
 public class ActivityReqDto {
     @NotBlank(message = "활동명은 필수 입력 항목입니다. 최대 20자 까지 입력 가능")
     @Size(max = 20)
-    @Schema(description = "활동명", example = "대외활동", type="string")
+    @Schema(description = "활동명", example = "광고 기획 동아리", type="string")
     private String name;
 
     @NotBlank(message = "활동 별칭은 필수 입력 항목입니다. 최대 20자 까지 입력 가능")
@@ -30,10 +32,6 @@ public class ActivityReqDto {
     @NotNull(message = "활동 기간을 알고 있는지 여부를 나타냅니다.")
     @Schema(description = "활동 기간 인지 여부", example = "false", type = "boolean")
     private Boolean unknown;
-
-//    @Size(max = 200)
-//    @Schema(description = "활동 내역", example = "주요 활동 내용을 요약하여 작성해주세요. 최대 50자 까지 입력 가능 선택사항입니다.", type = "string")
-//    private String summary;
 
     @NotNull(message = "활동 시작 날짜는 필수 입력 항목입니다.")
     @JsonFormat(shape=JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
@@ -59,7 +57,12 @@ public class ActivityReqDto {
 
     //팀 선택시 입력 사항인
     @Schema(description = "인원, 숫자만, 2자리까지 직접 입력 가능", example = "30", type = "int")
+    @Min(0)
+    @Max(99)
     private int teamSize;
+
     @Schema(description = "기여도, 숫자만, 100이내 직접 입력 가능", example = "20", type = "int")
+    @Min(0)
+    @Max(100)
     private int contribution;
 }

--- a/src/main/java/umc/kkijuk/server/career/dto/CircleReqDto.java
+++ b/src/main/java/umc/kkijuk/server/career/dto/CircleReqDto.java
@@ -32,9 +32,6 @@ public class CircleReqDto {
     @Schema(description = "활동 기간 인지 여부", example = "false", type = "boolean")
     private Boolean unknown;
 
-//    @Size(max = 200)
-//    @Schema(description = "활동 내역", example = "주요 활동 내용을 요약하여 작성해주세요. 최대 200자 까지 입력 가능 선택사항입니다.", type = "string")
-//    private String summary;
 
     @NotNull(message = "활동 시작 날짜는 필수 입력 항목입니다.")
     @JsonFormat(shape=JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")

--- a/src/main/java/umc/kkijuk/server/career/dto/CompetitionReqDto.java
+++ b/src/main/java/umc/kkijuk/server/career/dto/CompetitionReqDto.java
@@ -2,6 +2,8 @@ package umc.kkijuk.server.career.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -32,9 +34,6 @@ public class CompetitionReqDto {
     @Schema(description = "활동 기간 인지 여부", example = "false", type = "boolean")
     private Boolean unknown;
 
-//    @Size(max = 200)
-//    @Schema(description = "활동 내역", example = "주요 활동 내용을 요약하여 작성해주세요. 최대 200자 까지 입력 가능 선택사항입니다.", type = "string")
-//    private String summary;
 
     @NotNull(message = "활동 시작 날짜는 필수 입력 항목입니다.")
     @JsonFormat(shape=JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
@@ -56,8 +55,13 @@ public class CompetitionReqDto {
     private Boolean isTeam;
 
     //팀 선택시 입력 사항인
+    @Min(0)
+    @Max(99)
     @Schema(description = "인원, 숫자만, 2자리까지 직접 입력 가능", example = "4", type = "int")
     private int teamSize;
+
+    @Min(0)
+    @Max(100)
     @Schema(description = "기여도, 숫자만, 100이내 직접 입력 가능", example = "30", type = "int")
     private int contribution;
 

--- a/src/main/java/umc/kkijuk/server/career/dto/EduCareerReqDto.java
+++ b/src/main/java/umc/kkijuk/server/career/dto/EduCareerReqDto.java
@@ -2,6 +2,8 @@ package umc.kkijuk.server.career.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -33,10 +35,6 @@ public class EduCareerReqDto {
     @Schema(description = "활동 기간 인지 여부", example = "false", type = "boolean")
     private Boolean unknown;
 
-//    @Size(max = 200)
-//    @Schema(description = "활동 내역", example = "주요 활동 내용을 요약하여 작성해주세요. 최대 200자 까지 입력 가능 선택사항입니다.", type = "string")
-//    private String summary;
-
     @NotNull(message = "활동 시작 날짜는 필수 입력 항목입니다.")
     @JsonFormat(shape=JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     @Schema(description = "활동 시작 날짜", example = "2024-04-14", type="string")
@@ -55,5 +53,7 @@ public class EduCareerReqDto {
 
     @NotNull(message = "교육시간는 필수 입력 항목입니다. 최대 4자리까지 숫자 입력 가능")
     @Schema(description = "4자리까지 직접 입력 가능", example = "126", type = "int")
+    @Max(9999)
+    @Min(0)
     private Integer time;
 }

--- a/src/main/java/umc/kkijuk/server/career/dto/ProjectReqDto.java
+++ b/src/main/java/umc/kkijuk/server/career/dto/ProjectReqDto.java
@@ -2,6 +2,8 @@ package umc.kkijuk.server.career.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -43,7 +45,7 @@ public class ProjectReqDto {
 
     //프로젝트 필수 입력사항
     @NotNull(message = "프로젝트 소속은 필수 입력 항목입니다.")
-    @Schema(description = "프로젝트 소 ", example = "OTHER", type = "string", allowableValues = {"ON_CAMPUS", "OFF_CAMPUS", "OTHER"})
+    @Schema(description = "프로젝트 소속 ", example = "OTHER", type = "string", allowableValues = {"ON_CAMPUS", "OFF_CAMPUS", "OTHER"})
     private ProjectType location;
 
     @NotNull(message = "팀일 경우 true, 팀이 아닐 경우 false")
@@ -51,8 +53,13 @@ public class ProjectReqDto {
     private Boolean isTeam;
 
     //팀 선택시 입력 사항 ( 선택 )
+    @Min(0)
+    @Max(99)
     @Schema(description = "인원, 숫자만, 2자리까지 직접 입력 가능", example = "4", type = "int")
     private int teamSize;
+
+    @Min(0)
+    @Max(100)
     @Schema(description = "기여도, 숫자만, 100이내 직접 입력 가능", example = "80", type = "int")
     private int contribution;
 

--- a/src/main/java/umc/kkijuk/server/career/service/CareerSearchServiceImpl.java
+++ b/src/main/java/umc/kkijuk/server/career/service/CareerSearchServiceImpl.java
@@ -37,6 +37,7 @@ public class CareerSearchServiceImpl implements CareerSearchService{
     private final CareerDetailRepository detailRepository;
     private final TagRepository tagRepository;
 
+    // 타임라인 관련
     @Override
     public List<TimelineResponse> findCareerForTimeline(Member requestMember) {
         Long memberId = requestMember.getId();
@@ -174,6 +175,7 @@ public class CareerSearchServiceImpl implements CareerSearchService{
 
         return baseCareers;
     }
+    //활동 상세
     @Override
     public BaseCareerResponse findCareer(Member requestMember, Long careerId, String type) {
         switch (type.toLowerCase()) {
@@ -230,6 +232,7 @@ public class CareerSearchServiceImpl implements CareerSearchService{
         }
     }
 
+    //태그 조회
     @Override
     public FindTagResponse.SearchTagResponse findAllTag(Member requestMember, String keyword) {
         List<Tag> tags = tagRepository.findByKeywordAndMemberId(keyword, requestMember.getId());
@@ -281,9 +284,9 @@ public class CareerSearchServiceImpl implements CareerSearchService{
         careers.addAll(etcRepository.findByMemberIdAndNameContaining(requestMember.getId(),keyword));
 
         if ("new".equalsIgnoreCase(sort)) {
-            careers.sort(Comparator.comparing(BaseCareer::getEnddate).reversed());
+            careers = careers.stream().sorted(Comparator.comparing(BaseCareer::getStartdate).reversed()).collect(Collectors.toList());
         } else {
-            careers.sort(Comparator.comparing(BaseCareer::getEnddate));
+            careers = careers.stream().sorted(Comparator.comparing(BaseCareer::getStartdate)).collect(Collectors.toList());
         }
 
         return careers.stream()
@@ -382,11 +385,10 @@ public class CareerSearchServiceImpl implements CareerSearchService{
             }
         }
         if (sort.equals("new")) {
-            result.stream().sorted(Comparator.comparing(FindDetailResponse::getEndDate).reversed());
+            return result.stream().sorted(Comparator.comparing(FindDetailResponse::getStartDate).reversed()).collect(Collectors.toList());
         } else {
-            result.stream().sorted(Comparator.comparing(FindDetailResponse::getEndDate).reversed());
+            return result.stream().sorted(Comparator.comparing(FindDetailResponse::getStartDate)).collect(Collectors.toList());
         }
-        return result;
 
     }
 
@@ -402,18 +404,7 @@ public class CareerSearchServiceImpl implements CareerSearchService{
             default: return null;
         }
     }
-//    private Long getCareerId(BaseCareerDetail detail) {
-//        switch (detail.getCareerType()) {
-//            case ACTIVITY: return detail.getActivity().getId();
-//            case PROJECT: return detail.getProject().getId();
-//            case EMP: return detail.getEmployment().getId();
-//            case EDU: return detail.getEduCareer().getId();
-//            case COM: return detail.getCompetition().getId();
-//            case CIRCLE: return detail.getCircle().getId();
-//            case ETC: return detail.getEtc().getId();
-//            default: return null;
-//        }
-//    }
+
     private CareerSearchServiceImpl.FindDetailInfo extractDetailInfo(List<BaseCareerDetail> details) {
         if (details.isEmpty()) {
             return new CareerSearchServiceImpl.FindDetailInfo(null, null, null, null);

--- a/src/main/java/umc/kkijuk/server/detail/domain/BaseCareerDetail.java
+++ b/src/main/java/umc/kkijuk/server/detail/domain/BaseCareerDetail.java
@@ -2,7 +2,6 @@ package umc.kkijuk.server.detail.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-import umc.kkijuk.server.career.domain.*;
 import umc.kkijuk.server.common.domian.base.BaseEntity;
 import umc.kkijuk.server.detail.domain.mapping.CareerDetailTag;
 
@@ -39,38 +38,6 @@ public class BaseCareerDetail extends BaseEntity {
     @Builder.Default
     @OneToMany(mappedBy = "baseCareerDetail", cascade = CascadeType.ALL)
     private List<CareerDetailTag> careerTagList = new ArrayList<>();
-
-
-
-
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name="activity_id")
-//    private Activity activity;
-//
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name="circle_id")
-//    private Circle circle;
-//
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name="competition_id")
-//    private Competition competition;
-//
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name="edu_id")
-//    private EduCareer eduCareer;
-//
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name="employment_id")
-//    private Employment employment;
-//
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name="project_id")
-//    private Project project;
-//
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name="etc_id")
-//    private CareerEtc etc;
-
 
 
 

--- a/src/main/java/umc/kkijuk/server/detail/dto/converter/BaseCareerDetailConverter.java
+++ b/src/main/java/umc/kkijuk/server/detail/dto/converter/BaseCareerDetailConverter.java
@@ -1,6 +1,5 @@
 package umc.kkijuk.server.detail.dto.converter;
 
-import umc.kkijuk.server.career.domain.*;
 import umc.kkijuk.server.detail.domain.BaseCareerDetail;
 import umc.kkijuk.server.detail.domain.CareerType;
 import umc.kkijuk.server.detail.dto.CareerDetailReqDto;
@@ -10,8 +9,7 @@ import java.util.ArrayList;
 
 public class BaseCareerDetailConverter {
 
-    public static BaseCareerDetail toBaseCareerDetail(Member requestMember,
-        CareerDetailReqDto request, Long careerId, CareerType type) {
+    public static BaseCareerDetail toBaseCareerDetail(Member requestMember, CareerDetailReqDto request, Long careerId, CareerType type) {
 
         return BaseCareerDetail.builder()
             .careerType(type)

--- a/src/main/java/umc/kkijuk/server/member/domain/Member.java
+++ b/src/main/java/umc/kkijuk/server/member/domain/Member.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 import umc.kkijuk.server.common.converter.MemberJobListConverter;
@@ -63,8 +64,9 @@ public class Member extends BaseEntity {
 
     private LocalDate deleteDate;
 
+    @Builder.Default
     @Convert(converter = StringListToStringConverter.class)
-    private List<String> recruitTags;
+    private List<String> recruitTags=new ArrayList<>();
 
 
 //    @NotNull
@@ -154,4 +156,8 @@ public class Member extends BaseEntity {
     public void setRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
+    public void setRecruitTags(List<String> recruitTags) {
+        this.recruitTags = (recruitTags != null) ? recruitTags : new ArrayList<>();
+    }
+
 }

--- a/src/main/java/umc/kkijuk/server/member/service/MemberServiceImpl.java
+++ b/src/main/java/umc/kkijuk/server/member/service/MemberServiceImpl.java
@@ -23,6 +23,7 @@ import umc.kkijuk.server.member.dto.*;
 import umc.kkijuk.server.member.repository.MemberRepository;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -104,7 +105,12 @@ public class MemberServiceImpl implements MemberService {
     @Override
     @Transactional
     public List<String> addRecruitTag(Member member, String tag) {
+        if (member.getRecruitTags() == null) {
+            member.setRecruitTags(new ArrayList<>());
+        }
+
         List<String> recruitTags = member.getRecruitTags();
+
         if (recruitTags.contains(tag)) {
             throw new RecruitTagAlreadyExistException(tag);
         }


### PR DESCRIPTION
## 🌱 관련 이슈 
close #98 
## 📌 작업 내용 및 특이사항

1.  내 커리어 검색 부분에서 검색 결과를 "stratDate" 기준으로 정렬 기준을 수정하였습니다.
2. 내 커리어 response 부분에 Schema 명세를 추가하였습니다.
3. 내 커리어 reqDto에 조건을 추가하였습니다. ( 글자 수 등 )
4. 공고 태그 조회시, null일 경우 예외처리를 추가하였습니다.