### PR TITLE
♻️ Refactor : 이력서 학력 생성 부분 Schema 작성 및 입학,졸업 날짜 형식 변경

### DIFF
--- a/src/main/java/umc/kkijuk/server/common/converter/YearMonthAttributeConverter.java
+++ b/src/main/java/umc/kkijuk/server/common/converter/YearMonthAttributeConverter.java
@@ -1,0 +1,22 @@
+package umc.kkijuk.server.common.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+
+@Converter(autoApply = true)
+public class YearMonthAttributeConverter implements AttributeConverter<YearMonth, String> {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM");
+
+
+    @Override
+    public String convertToDatabaseColumn(YearMonth attribute) {
+        return (attribute == null) ? null : attribute.format(FORMATTER);
+    }
+
+    @Override
+    public YearMonth convertToEntityAttribute(String dbData) {
+        return (dbData == null) ? null : YearMonth.parse(dbData, FORMATTER);
+    }
+}

--- a/src/main/java/umc/kkijuk/server/record/controller/response/EducationResponse.java
+++ b/src/main/java/umc/kkijuk/server/record/controller/response/EducationResponse.java
@@ -1,5 +1,6 @@
 package umc.kkijuk.server.record.controller.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 import umc.kkijuk.server.record.domain.Education;
 
@@ -16,8 +17,10 @@ public class EducationResponse {
     private String schoolName;
     private String major;
     private String state;
-    private LocalDate admissionDate;
-    private LocalDate graduationDate;
+    @JsonFormat(pattern = "yyyy-MM")
+    private YearMonth admissionDate;
+    @JsonFormat(pattern = "yyyy-MM")
+    private YearMonth graduationDate;
     private Boolean isCurrent;
 
     public EducationResponse(Education education) {
@@ -31,7 +34,11 @@ public class EducationResponse {
         this.isCurrent=determineIsCurrent(graduationDate);
     }
 
-    private static Boolean determineIsCurrent(LocalDate graduationDate) {
-        return graduationDate.isAfter(LocalDate.now());
+    private static Boolean determineIsCurrent(YearMonth graduationDate) {
+        if (graduationDate == null) {
+            return false;
+        }
+        LocalDate graduationEndDate = graduationDate.atEndOfMonth();
+        return graduationEndDate.isAfter(LocalDate.now());
     }
 }

--- a/src/main/java/umc/kkijuk/server/record/domain/Education.java
+++ b/src/main/java/umc/kkijuk/server/record/domain/Education.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import umc.kkijuk.server.common.converter.YearMonthAttributeConverter;
 import umc.kkijuk.server.common.domian.base.BaseEntity;
 
 import java.time.LocalDate;
@@ -28,27 +29,14 @@ public class Education extends BaseEntity {
     private String schoolName;
     private String major;
     private String state;
-    private LocalDate admissionDate;
-    private LocalDate graduationDate;
+    @Convert(converter = YearMonthAttributeConverter.class)
+    private YearMonth admissionDate;
+    @Convert(converter = YearMonthAttributeConverter.class)
+    private YearMonth graduationDate;
 
-//    @Builder
-//    public Education(Record record, String category, String schoolName, String major
-//    , String state, YearMonth admissionDate, YearMonth graduationDate) {
-//        this.record = record;
-//        this.category = category;
-//        this.schoolName = schoolName;
-//        this.major = major;
-//        this.state = state;
-//        this.admissionDate = admissionDate;
-//        this.graduationDate = graduationDate;
-//    }
-
-   /* public void setRecord(Record record) {
-        this.record = record;
-    }*/
 
     public void changeEducationInfo(String category, String schoolName, String major
-            , String state, LocalDate admissionDate, LocalDate graduationDate) {
+            , String state, YearMonth admissionDate, YearMonth graduationDate) {
         this.category = category;
         this.schoolName = schoolName;
         this.major = major;

--- a/src/main/java/umc/kkijuk/server/record/dto/EducationReqDto.java
+++ b/src/main/java/umc/kkijuk/server/record/dto/EducationReqDto.java
@@ -1,9 +1,11 @@
 package umc.kkijuk.server.record.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import java.time.Year;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,16 +19,30 @@ import java.time.YearMonth;
 @NoArgsConstructor
 @Getter
 public class EducationReqDto {
+
     @NotBlank(message = "입력하지 않은 항목이 있습니다.")
+    @Schema(description = "학력 구분", example = "재학", type="string")
     private String category;
+
     @NotBlank(message = "입력하지 않은 항목이 있습니다.")
+    @Schema(description = "학교 이름", example = "끼적대학교", type="string")
     private String schoolName;
+
     @NotBlank(message = "입력하지 않은 항목이 있습니다.")
+    @Schema(description = "전공", example = "컴퓨터공학과", type="string")
     private String major;
+
     @NotBlank(message = "입력하지 않은 항목이 있습니다.")
+    @Schema(description = "학력상태", example = "휴학", type="string")
     private String state;
+
     @NotNull(message = "입력하지 않은 항목이 있습니다.")
-    private LocalDate admissionDate;
+    @JsonFormat(pattern = "yyyy-MM")
+    @Schema(type = "string", example = "2021-03")
+    private YearMonth admissionDate;
+
     @NotNull(message = "입력하지 않은 항목이 있습니다.")
-    private LocalDate graduationDate;
+    @JsonFormat(pattern = "yyyy-MM")
+    @Schema(type = "string", example = "2025-08")
+    private YearMonth graduationDate;
 }

--- a/src/main/java/umc/kkijuk/server/record/dto/RecordReqDto.java
+++ b/src/main/java/umc/kkijuk/server/record/dto/RecordReqDto.java
@@ -1,5 +1,6 @@
 package umc.kkijuk.server.record.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -12,9 +13,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 public class RecordReqDto {
+    @Schema(description = "주소", example = "서울특별시 중구 세종대로 110", type="string")
     private String address;
+
+    @Schema(description = "사진 주소", example = "testtestimageaddress", type="string")
     private String profileImageUrl;
+
     @NotBlank(message = "이메일을 입력해주세요.")
     @Email(message = "올바른 이메일 주소를 입력해주세요.")
+    @Schema(description = "이메일", example = "kkijuk@gmail.com", type="string")
     private String email;
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #113 

## 📌 작업 내용 및 특이사항
- 학력 시작일(admissionDate), 종료일(graduationDate)의 형식을 yyyy-MM로 변환하여 응답하도록 수정하였습니다.
- Education 엔티티의 필드를 LocalDate → YearMonth로 엔티티 필드 타입 변경하였습니다.
- YearMonth를 JPA에서 매핑할 수 있도록 컨버터(YearMonthAttributeConverter) 추가
- Swagger에서 yyyy-MM 형식으로 인식되도록 @Schema 추가
- 학력 관련 Dto에 Schema 추가

## 📝 참고사항
- 기존 데이터(yyyy-MM-dd 형식)가 있다면, YearMonth로 변환하는 마이그레이션 필요