### PR TITLE
Refactor : 공고 후기 1000자 제한 추가 및 DB 컬럼 VARCHAR(1000)으로 변경

### DIFF
--- a/src/main/java/umc/kkijuk/server/review/domain/RecruitReviewDto.java
+++ b/src/main/java/umc/kkijuk/server/review/domain/RecruitReviewDto.java
@@ -1,5 +1,6 @@
 package umc.kkijuk.server.review.domain;
 
+import jakarta.persistence.Column;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import umc.kkijuk.server.recruit.domain.RecruitStatus;

--- a/src/main/java/umc/kkijuk/server/review/domain/Review.java
+++ b/src/main/java/umc/kkijuk/server/review/domain/Review.java
@@ -1,5 +1,6 @@
 package umc.kkijuk.server.review.domain;
 
+import jakarta.persistence.Column;
 import lombok.Builder;
 import lombok.Getter;
 import umc.kkijuk.server.recruit.domain.Recruit;

--- a/src/main/java/umc/kkijuk/server/review/domain/ReviewCreate.java
+++ b/src/main/java/umc/kkijuk/server/review/domain/ReviewCreate.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -19,6 +20,7 @@ public class ReviewCreate {
     private String title;
 
     @Schema(description = "공고 후기 내용", example = "Dijkstra 알고리즘을 활용하는 문제", type = "string")
+    @Size(max = 1000, message = "공고 후기 내용은 1000자 이내로 작성해주세요.")
     private String content;
 
     @NotNull(message = "날짜는 필수 입력 항목입니다.")

--- a/src/main/java/umc/kkijuk/server/review/domain/ReviewUpdate.java
+++ b/src/main/java/umc/kkijuk/server/review/domain/ReviewUpdate.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -18,6 +19,7 @@ public class ReviewUpdate {
     private String title;
 
     @Schema(description = "변경될 공고 후기 내용", example = "변경될 내용", type = "string")
+    @Size(max = 1000, message = "공고 후기 내용은 1000자 이내로 작성해주세요.")
     private String content;
 
     @NotNull(message = "날짜는 필수 입력 항목입니다.")


### PR DESCRIPTION
- 공고 후기 추가 및 수정 시 content 값 1000자 size 제한 추가
- DB의 review 테이블의 content 컬럼 varchar(255) -> varchar(1000)으로 변경