### PR TITLE
chore: Exception notification to discord: Add RecruitTagAlreadyExists…

### DIFF
--- a/src/main/java/umc/kkijuk/server/common/controller/ExceptionControllerAdvice.java
+++ b/src/main/java/umc/kkijuk/server/common/controller/ExceptionControllerAdvice.java
@@ -120,6 +120,12 @@ public class ExceptionControllerAdvice {
         return new ErrorResponse(e.getMessage());
     }
 
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(RecruitTagAlreadyExistException.class)
+    public ErrorResponse RecruitTagAlreadyExistException(RecruitTagAlreadyExistException e) {
+        return new ErrorResponse(e.getMessage());
+    }
+
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(EmailAlreadyExistsException.class)

--- a/src/main/java/umc/kkijuk/server/common/domian/exception/RecruitTagAlreadyExistException.java
+++ b/src/main/java/umc/kkijuk/server/common/domian/exception/RecruitTagAlreadyExistException.java
@@ -1,5 +1,8 @@
 package umc.kkijuk.server.common.domian.exception;
 
+import umc.kkijuk.server.common.SkipDiscordNotification;
+
+@SkipDiscordNotification
 public class RecruitTagAlreadyExistException extends RuntimeException {
     public RecruitTagAlreadyExistException(String tag) {
         super("RecruitTag [" + tag + "] already exists");


### PR DESCRIPTION
RecruitTagAlreadyExistException 에서 알림오는걸 Skip합니다