### PR TITLE
Refactor : 회원가입 플로우 변경에 따른 회원가입 및 추가정보 입력 API 수정

### DIFF
--- a/src/main/java/umc/kkijuk/server/member/controller/MemberController.java
+++ b/src/main/java/umc/kkijuk/server/member/controller/MemberController.java
@@ -145,7 +145,6 @@ public class MemberController {
     public ResponseEntity<Map<String, Object>> addProfile(@RequestHeader("Authorization") String token,
                                                    @RequestBody @Valid ProfileInputDto profileInputDto){
         Member member = loginUser.extractMemberId(token);
-        Long memberId = member.getId();
         memberService.completeProfile(member, profileInputDto);
 
         Map<String, Object> tokens = new HashMap<>();

--- a/src/main/java/umc/kkijuk/server/member/dto/ProfileInputDto.java
+++ b/src/main/java/umc/kkijuk/server/member/dto/ProfileInputDto.java
@@ -12,15 +12,12 @@ import java.util.List;
 @NoArgsConstructor
 public class ProfileInputDto {
 
-    @NotNull(message = "서비스 약관 동의 여부는 필수 값입니다.")
     @Schema(description = "서비스 약관 동의 여부", example = "true", type = "boolean")
     private Boolean isTermsAgreed;
 
-    @NotNull(message = "개인정보 처리 방침 동의 여부는 필수 값입니다.")
     @Schema(description = "개인정보 처리 방침 동의 여부", example = "true", type = "boolean")
     private Boolean isPrivacyAgreed;
 
-    @NotNull(message = "마케팅 정보 수신 동의 여부는 필수 값입니다.")
     @Schema(description = "마케팅 정보 수신 동의 여부", example = "BOTH", type = "string",allowableValues = {
             "BOTH",
             "EMAIL",
@@ -28,7 +25,6 @@ public class ProfileInputDto {
             "NONE" })
     private MarketingAgree isMarketingAgreed;
 
-    @NotNull(message = "회원 직업 정보는 필수 값입니다.")
     @Schema(description = "회원 직업 정보", example = "JOB_SEEKER", type = "array"/*, allowableValues = {
             "MIDDLE_OR_HIGH_SCHOOL", // 중/고등학생
             "JOB_SEEKER",            // 취준생

--- a/src/main/java/umc/kkijuk/server/member/service/MemberServiceImpl.java
+++ b/src/main/java/umc/kkijuk/server/member/service/MemberServiceImpl.java
@@ -14,6 +14,7 @@ import umc.kkijuk.server.common.domian.exception.*;
 import umc.kkijuk.server.common.domian.status.AuthErrorStatus;
 import umc.kkijuk.server.member.controller.response.MemberEmailResponse;
 import umc.kkijuk.server.member.controller.response.MemberInfoResponse;
+import umc.kkijuk.server.member.domain.MarketingAgree;
 import umc.kkijuk.server.member.domain.Member;
 import umc.kkijuk.server.member.domain.Role;
 import umc.kkijuk.server.member.domain.SocialType;
@@ -166,6 +167,10 @@ public class MemberServiceImpl implements MemberService {
         newMember.setSocialType(SocialType.KAKAO);
         newMember.setProfileComplete(false);
         newMember.setUserState(State.ACTIVATE);
+        newMember.setTermsAgree(true);
+        newMember.setPrivacyAgree(true);
+        newMember.setMarketingAgree(MarketingAgree.NONE);
+        newMember.setProfileComplete(true);
 
 
         log.info("신규 사용자 생성 - Kakao ID: {}, 이메일: {}, 이름: {}, 전화번호: {}, 생년월일: {}", kakaoId, email, name, phoneNumber, birthDate);
@@ -216,7 +221,10 @@ public class MemberServiceImpl implements MemberService {
         newMember.setRole(Role.ROLE_USER);
         newMember.setSocialType(SocialType.NAVER);
         newMember.setUserState(State.ACTIVATE);
-        newMember.setProfileComplete(false);
+        newMember.setTermsAgree(true);
+        newMember.setPrivacyAgree(true);
+        newMember.setMarketingAgree(MarketingAgree.NONE);
+        newMember.setProfileComplete(true);
 
 
         log.info("신규 사용자 생성 - Naver ID: {}, 이메일: {}, 이름: {}, 전화번호: {}, 생년월일: {}", naverId, email, name, phoneNumber, birthDate);
@@ -230,7 +238,6 @@ public class MemberServiceImpl implements MemberService {
         member.setPrivacyAgree(profileInputDto.getIsPrivacyAgreed());
         member.setMarketingAgree(profileInputDto.getIsMarketingAgreed());
         member.setMemberJob(profileInputDto.getMemberJob());
-        member.setProfileComplete(true);
         return memberRepository.save(member);
     }
 

--- a/src/main/java/umc/kkijuk/server/member/service/MemberServiceImpl.java
+++ b/src/main/java/umc/kkijuk/server/member/service/MemberServiceImpl.java
@@ -170,7 +170,7 @@ public class MemberServiceImpl implements MemberService {
         newMember.setTermsAgree(true);
         newMember.setPrivacyAgree(true);
         newMember.setMarketingAgree(MarketingAgree.NONE);
-        newMember.setProfileComplete(true);
+        newMember.setProfileComplete(false);
 
 
         log.info("신규 사용자 생성 - Kakao ID: {}, 이메일: {}, 이름: {}, 전화번호: {}, 생년월일: {}", kakaoId, email, name, phoneNumber, birthDate);
@@ -224,7 +224,7 @@ public class MemberServiceImpl implements MemberService {
         newMember.setTermsAgree(true);
         newMember.setPrivacyAgree(true);
         newMember.setMarketingAgree(MarketingAgree.NONE);
-        newMember.setProfileComplete(true);
+        newMember.setProfileComplete(false);
 
 
         log.info("신규 사용자 생성 - Naver ID: {}, 이메일: {}, 이름: {}, 전화번호: {}, 생년월일: {}", naverId, email, name, phoneNumber, birthDate);
@@ -234,10 +234,9 @@ public class MemberServiceImpl implements MemberService {
     @Override
     @Transactional
     public Member completeProfile(Member member, ProfileInputDto profileInputDto) {
-        member.setTermsAgree(profileInputDto.getIsTermsAgreed());
-        member.setPrivacyAgree(profileInputDto.getIsPrivacyAgreed());
         member.setMarketingAgree(profileInputDto.getIsMarketingAgreed());
         member.setMemberJob(profileInputDto.getMemberJob());
+        member.setProfileComplete(true);
         return memberRepository.save(member);
     }
 


### PR DESCRIPTION
### 기존 배경
- 기존에는 회원가입 이후 별도의 API로 이용약관 동의와 개인정보 수집 동의 값을 true로 받도록 되어 있었음.
- 회원가입 플로우가 네이버.카카오 쪽으로 이관되면서, 회원가입 시점에 바로 termAgree, privacyAgree 값을 true로 세팅하도록 변경함

### 주요 변경사항

**1. 회원가입 API**
termAgree, privacyAgree 필드를 회원가입 시 기본값 true로 설정.
**2. 추가정보 입력 API**
기존에는 termAgree, privacyAgree 필드를 @NotNull 로 받았으나,
→ 회원가입 단계에서 이미 true로 설정되므로 해당 제약조건 제거.
나머지 구조는 그대로 두어 프론트와의 호환성 유지
